### PR TITLE
Update CMakeLists.txt to build ocean-letkf with local libs

### DIFF
--- a/.github/workflows/cmake_build_ocnletkf_gfortran.yml
+++ b/.github/workflows/cmake_build_ocnletkf_gfortran.yml
@@ -26,9 +26,9 @@ jobs:
     - name: check nf-config
       run: nf-config --all
 
-    - name: Configure letkf for model: mom6
+    - name: Configure letkf for model MOM6
       run: cmake -B ${{github.workspace}}/build_ocnletkf -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_Fortran_COMPILER=gfortran -DSOLO_BUILD=ON -DMODEL=mom6
 
-    - name: Build letkf for model: mom6
+    - name: Build letkf for model MOM6
       run: cmake --build ${{github.workspace}}/build_ocnletkf --config ${{env.BUILD_TYPE}}
 

--- a/.github/workflows/cmake_build_ocnletkf_gfortran.yml
+++ b/.github/workflows/cmake_build_ocnletkf_gfortran.yml
@@ -1,0 +1,34 @@
+name: cmake_build_ocnletkf_gfortran
+
+on:
+  push:
+  pull_request:
+
+env:
+  BUILD_TYPE: Debug
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: install MPI
+      run: sudo apt install mpich   
+
+    - name: install NetCDF
+      run: sudo apt install libnetcdf-dev libnetcdff-dev netcdf-bin
+
+    - name: check nc-config
+      run: nc-config --all
+
+    - name: check nf-config
+      run: nf-config --all
+
+    - name: Configure letkf for model: mom6
+      run: cmake -B ${{github.workspace}}/build_ocnletkf -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_Fortran_COMPILER=gfortran -DSOLO_BUILD=ON -DMODEL=mom6
+
+    - name: Build letkf for model: mom6
+      run: cmake --build ${{github.workspace}}/build_ocnletkf --config ${{env.BUILD_TYPE}}
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,1 +1,51 @@
-add_subdirectory( src)
+cmake_minimum_required(VERSION 3.18)
+option(SOLO_BUILD "build ocean-letkf with local libs" OFF)
+
+if (SOLO_BUILD) # build ocean-letkf with local libs. Most users should use this 
+
+    project(ocean-letkf LANGUAGES Fortran)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+
+    message(STATUS "OCEAN-LETKF: SOLO_BUILD=${SOLO_BUILD}, search local libs: MPI, NetCDF")
+
+    # find MPI libs
+    find_package(MPI COMPONENTS Fortran REQUIRED)
+
+    # find NetCDF Fortran libs
+    ## download additional CMakeModules for NetCDF if FindNetCDF.cmake is not found.
+    ## this is done only once
+    set(EXTERNAL_CMAKE_MODULE_URL "https://github.com/NOAA-EMC/CMakeModules.git")
+    set(EXTERNAL_CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/support/CMakeModules/Modules)
+    if (NOT EXISTS ${EXTERNAL_CMAKE_MODULE_PATH}/FindNetCDF.cmake)
+       message(WARNING "OCEAN-LETKF: File (${EXTERNAL_CMAKE_MODULE_PATH}/FindNetCDF.cmake) not found.")
+       message(STATUS "Pull additional CMakeModules from ${EXTERNAL_CMAKE_MODULE_URL}")
+
+       find_package(Git REQUIRED)
+       execute_process(COMMAND git clone -b release/public-v1 ${EXTERNAL_CMAKE_MODULE_URL}
+                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/support) 
+    endif()
+    list(APPEND CMAKE_MODULE_PATH ${EXTERNAL_CMAKE_MODULE_PATH};${CMAKE_MODULE_PATH})
+    find_package(NetCDF COMPONENTS Fortran REQUIRED)
+
+    # compiler-dependent flags   
+    if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+        set(CMAKE_Fortran_FLAGS "-O2 -ffree-line-length-none -frecord-marker=4 -finit-local-zero -fbacktrace -g")
+        set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -ffree-line-length-none -frecord-marker=4 -finit-local-zero -fbacktrace -fcheck=bounds")
+        set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -ffree-line-length-none -frecord-marker=4 -finit-local-zero")
+        ## additional flags for gfortran version >= 10.0
+        if (${CMAKE_Fortran_COMPILER_VERSION} VERSION_GREATER_EQUAL 10) 
+           set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch -fallow-invalid-boz")
+        endif ()
+    elseif (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+        set(CMAKE_Fortran_FLAGS "-O2 -g -traceback")
+        set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -traceback -check bounds")
+        set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+    endif()
+
+else() # build as an application with GEOS-ESM infra
+
+    message(STATUS "OCEAN-LETKF: SOLO_BUILD=${SOLO_BUILD}, build with GEOS-ESM infra")
+
+endif()
+
+add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Ocean-LETKF:  
+[![cmake_build_ocnletkf_gfortran](https://github.com/cd10kfsu/Ocean-LETKF/actions/workflows/cmake_build_ocnletkf_gfortran.yml/badge.svg?branch=cmake-update)](https://github.com/cd10kfsu/Ocean-LETKF/actions/workflows/cmake_build_ocnletkf_gfortran.yml)
+
 Main repository for the Ocean-LETKF development
 
 # Getting started with git:

--- a/build/make_obsop.roms.sh
+++ b/build/make_obsop.roms.sh
@@ -45,7 +45,7 @@ name=${MACHINE}_${model}
 PGM=obsop.$name
 
 # Build directory
-BDIR=$CDIR/obsop_build/$name.build
+BDIR=$CDIR/build_obsop/$name.build
 mkdir -p $BDIR
 cd $BDIR
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.18)
+#cmake_minimum_required (VERSION 3.18)
 
 include(GNUInstallDirs)
 
@@ -58,7 +58,12 @@ set (SRCS
   )
 
 add_library(OCN.letkf ${SRCS})
-target_link_libraries(OCN.letkf PUBLIC NetCDF::NetCDF_Fortran MPI::MPI_Fortran Threads::Threads)
+if (${SOLO_BUILD})
+    set (OCNLETKF_LD_LIBS NetCDF::NetCDF_Fortran MPI::MPI_Fortran)
+else()
+    set (OCNLETKF_LD_LIBS NetCDF::NetCDF_Fortran MPI::MPI_Fortran Threads::Threads)
+endif()
+target_link_libraries(OCN.letkf PUBLIC ${OCNLETKF_LD_LIBS})
 set_target_properties (OCN.letkf PROPERTIES Fortran_PREPROCESS ON) # Need to preprocess .f90 files for ifdef on next line
 target_compile_definitions(OCN.letkf PRIVATE DYNAMIC)
 install(TARGETS OCN.letkf)


### PR DESCRIPTION
## Brief description
@StevePny Former CMakeLists.txt built ocean-letkf for MOM6 by using NASA GEOS-ESM infra.

The updated one allows to build ocean-letkf with local MPI and NetCDF libs, by adding the option "-DSOLO_BUILD=ON". The default value of SOLO_BUILD is OFF, which ensures the updated CMakeLists.txt does not change the default CMake building process. 

This pull request also fixes a minor bug for `build/make_obsop.roms.sh`.



## Features added

1. Update CMake Config files to provide a building option (-DSOLO_BUILD=ON) to build ocean-letkf with local NetCDF and MPI libs, instead of using NASA GEOS-ESM infra.

## Bugs fixed
1. Update `build/make_obsop.roms.sh` so that its obsop is built under the designed directory `build/build_obsop`

## Test changes

N/A

## Documentation changes

I would like to add a wiki page for building ocean-letkf with CMake, but I don't have the editing access to wiki  

## Does this create a breaking change?

N/A
