### PR TITLE
Add I/O and obsop for geostationary SST (resolved #133)

### DIFF
--- a/.github/workflows/build_gfortran.yml
+++ b/.github/workflows/build_gfortran.yml
@@ -20,6 +20,7 @@ jobs:
 
     - name: "install MPI & NetCDF"
       run: |
+           sudo apt-get update
            sudo apt install mpich   
            sudo apt install libnetcdf-dev libnetcdff-dev netcdf-bin
 
@@ -54,6 +55,7 @@ jobs:
 
     - name: "install MPI & NetCDF"
       run: |
+           sudo apt-get update
            sudo apt install mpich   
            sudo apt install libnetcdf-dev libnetcdff-dev netcdf-bin
 

--- a/.github/workflows/get_data.yml
+++ b/.github/workflows/get_data.yml
@@ -32,11 +32,11 @@ jobs:
            rm -rf test_l2_sss
            ls -al
 
-    - name: "check: get_l2p_ghrsst_star.py"
+    - name: "check: get_l2p_ghrsst_geostationary.py"
       run: |
            cd ${{github.workspace}}/utils/obs_proc/level-2
            pwd
-           PYTHONPATH=../../pycommon ./get_l2p_ghrsst_star.py --start_date 20220110 --end_date 20220111 --sis ABI_G17 --outdir ./ --topdir_name test_l2p_sst --skip_remote_check  --get_nav_file --verbose --log
+           PYTHONPATH=../../pycommon ./get_l2p_ghrsst_geostationary.py --start_date 20220110 --end_date 20220111 --sis ABI_G17 --outdir ./ --topdir_name test_l2p_sst --skip_remote_check  --get_nav_file --verbose --log
            ls -al 
            ls -al ./test_l2p_sst/ABI_G17/2022/202201/20220111/
            ls -al ./test_l2p_sst/ABI_G17/nav

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,8 @@ if (SOLO_BUILD) # build ocean-letkf with local libs. Most users should use this
 
     # compiler-dependent flags   
     if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
-        set(CMAKE_Fortran_FLAGS "-O2 -ffree-line-length-none -frecord-marker=4 -finit-local-zero -fbacktrace -g")
-        set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -ffree-line-length-none -frecord-marker=4 -finit-local-zero -fbacktrace -fcheck=bounds")
+        set(CMAKE_Fortran_FLAGS "-O2 -ffree-line-length-none -frecord-marker=4 -finit-local-zero -fbacktrace")
+        set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -ffree-line-length-none -frecord-marker=4 -finit-local-zero -fbacktrace -fcheck=mem,pointer,bounds -fno-realloc-lhs")
         set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -ffree-line-length-none -frecord-marker=4 -finit-local-zero")
         ## additional flags for gfortran version >= 10.0
         if (${CMAKE_Fortran_COMPILER_VERSION} VERSION_GREATER_EQUAL 10) 

--- a/build/lnkcommon_obsop.sh
+++ b/build/lnkcommon_obsop.sh
@@ -60,6 +60,11 @@ cp $OBSDIR/gsw_pot_to_insitu.f90 ./
 cp $OBSDIR/read_ice_txt.f90 ./
 cp $OBSDIR/obsop_icefrac.f90 ./
 
+if [ "${model}" = "mom6" ]; then
+   cp $OBSDIR/obsop_sst_podaac.f90 ./
+fi
+
+
 if [ "${model}" = "hycom" ]; then
    cp $OBSDIR/read_bufr_hycom.f90 ./
    cp $OBSDIR/obsop_bufr_tprof_hycom.f90 ./

--- a/build/lnkcommon_obsop.sh
+++ b/build/lnkcommon_obsop.sh
@@ -62,8 +62,8 @@ cp $OBSDIR/obsop_icefrac.f90 ./
 
 IODIR=$root/support/io
 if [ "${model}" = "mom6" ]; then
-   cp $OBSDIR/read_abi_acspo.f90 ./
-   cp $OBSDIR/obsop_sst_acspo.f90 ./
+   cp $OBSDIR/read_geostationary.f90 ./
+   cp $OBSDIR/obsop_sst_geostationary.f90 ./
    cp $OBSDIR/w3movdat_full.f ./
    cp $IODIR/m_ncio.f90 ./
    cp $IODIR/*.f90.inc ./

--- a/build/lnkcommon_obsop.sh
+++ b/build/lnkcommon_obsop.sh
@@ -60,8 +60,13 @@ cp $OBSDIR/gsw_pot_to_insitu.f90 ./
 cp $OBSDIR/read_ice_txt.f90 ./
 cp $OBSDIR/obsop_icefrac.f90 ./
 
+IODIR=$root/support/io
 if [ "${model}" = "mom6" ]; then
-   cp $OBSDIR/obsop_sst_podaac.f90 ./
+   cp $OBSDIR/read_abi_acspo.f90 ./
+   cp $OBSDIR/obsop_sst_acspo.f90 ./
+   cp $OBSDIR/w3movdat_full.f ./
+   cp $IODIR/m_ncio.f90 ./
+   cp $IODIR/*.f90.inc ./
 fi
 
 

--- a/build/make_obsop.mom6_dynamic.sh
+++ b/build/make_obsop.mom6_dynamic.sh
@@ -86,6 +86,8 @@ $F90 $OMP $F90_OPT obsop_sprof.f90 -o ${PGM}.sprof.x *.o $NETCDF_LIB
 $F90 $OMP $F90_OPT obsop_adt.f90   -o ${PGM}.adt.x   *.o $NETCDF_LIB
 $F90 $OMP $F90_OPT obsop_sst.f90   -o ${PGM}.sst.x   *.o $NETCDF_LIB
 
+$F90 $OMP $F90_OPT $F90_FPP obsop_sst_podaac.f90   -o ${PGM}.sst_podaac.x   *.o $NETCDF_LIB
+
 rm -f *.mod
 rm -f *.o
 #--

--- a/build/make_obsop.mom6_dynamic.sh
+++ b/build/make_obsop.mom6_dynamic.sh
@@ -84,7 +84,7 @@ $F90 $OMP $F90_OPT $F90_OBJECT_FLAG $NETCDF_INC read_argo.f90
 $F90 $OMP $F90_OPT $F90_OBJECT_FLAG $NETCDF_INC read_avhrr_pathfinder.f90
 $F90 $OMP $F90_OPT $F90_OBJECT_FLAG $NETCDF_INC read_aviso_adt.f90
 
-$F90 $OMP $F90_OPT $F90_OBJECT_FLAG $NETCDF_INC read_abi_acspo.f90
+$F90 $OMP $F90_OPT $F90_OBJECT_FLAG $NETCDF_INC read_geostationary.f90
 
 $F90 $OMP $F90_OPT $F90_DEBUG $F90_FPP $F90_OBJECT_FLAG input_nml_${model}.f90
 
@@ -98,7 +98,7 @@ $F90 $OMP $F90_OPT obsop_sprof.f90 -o ${PGM}.sprof.x *.o $NETCDF_LIB
 $F90 $OMP $F90_OPT obsop_adt.f90   -o ${PGM}.adt.x   *.o $NETCDF_LIB
 $F90 $OMP $F90_OPT obsop_sst.f90   -o ${PGM}.sst.x   *.o $NETCDF_LIB
 
-$F90 $OMP $F90_OPT $F90_FPP obsop_sst_acspo.f90   -o ${PGM}.sst_acspo.x   *.o $NETCDF_LIB
+$F90 $OMP $F90_OPT $F90_FPP obsop_sst_geostationary.f90   -o ${PGM}.sst_geostationary.x   *.o $NETCDF_LIB
 
 rm -f *.mod
 rm -f *.o

--- a/build/make_obsop.mom6_dynamic.sh
+++ b/build/make_obsop.mom6_dynamic.sh
@@ -60,6 +60,15 @@ rm -f $BDIR/*.dat
 
 sh $CDIR/lnkcommon_obsop.sh $model $CDIR/../
 
+#--
+# F90GIO lib
+#--
+$F90 $OMP $F90_OPT $F90_DEBUG $F90_FPP $F90_OBJECT_FLAG $NETCDF_INC m_ncio.f90
+$F90 $OMP $F90_OPT $F90_DEBUG $F90_FPP $F90_OBJECT_FLAG $NETCDF_INC w3movdat_full.f
+
+
+
+
 $F90 $OMP $F90_OPT $INLINE $F90_OBJECT_FLAG SFMT.f90
 $F90 $OMP $F90_OPT $INLINE $F90_OBJECT_FLAG common.f90
 $F90 $OMP $F90_OPT $F90_DEBUG $F90_FPP $F90_OBJECT_FLAG params_model.f90
@@ -74,6 +83,9 @@ $F90 $OMP $F90_OPT $F90_OBJECT_FLAG compute_profile_error.f90
 $F90 $OMP $F90_OPT $F90_OBJECT_FLAG $NETCDF_INC read_argo.f90
 $F90 $OMP $F90_OPT $F90_OBJECT_FLAG $NETCDF_INC read_avhrr_pathfinder.f90
 $F90 $OMP $F90_OPT $F90_OBJECT_FLAG $NETCDF_INC read_aviso_adt.f90
+
+$F90 $OMP $F90_OPT $F90_OBJECT_FLAG $NETCDF_INC read_abi_acspo.f90
+
 $F90 $OMP $F90_OPT $F90_DEBUG $F90_FPP $F90_OBJECT_FLAG input_nml_${model}.f90
 
 #--
@@ -86,7 +98,7 @@ $F90 $OMP $F90_OPT obsop_sprof.f90 -o ${PGM}.sprof.x *.o $NETCDF_LIB
 $F90 $OMP $F90_OPT obsop_adt.f90   -o ${PGM}.adt.x   *.o $NETCDF_LIB
 $F90 $OMP $F90_OPT obsop_sst.f90   -o ${PGM}.sst.x   *.o $NETCDF_LIB
 
-$F90 $OMP $F90_OPT $F90_FPP obsop_sst_podaac.f90   -o ${PGM}.sst_podaac.x   *.o $NETCDF_LIB
+$F90 $OMP $F90_OPT $F90_FPP obsop_sst_acspo.f90   -o ${PGM}.sst_acspo.x   *.o $NETCDF_LIB
 
 rm -f *.mod
 rm -f *.o

--- a/config/ESSIC.bufr.sh
+++ b/config/ESSIC.bufr.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# BUFR lib is only used for model=hycom
+
+BUILD_BUFRLIB="yes"  # "yes" or "no"
+
+# variables to set if BUILD_BUFRLIB = "no"
+BUFR_DIR=/Users/cda14/Desktop/bufr_util/src/bufr_10.2.3
+BUFR_LIB="-L$BUFR_DIR/ -lbufr"
+
+# variables to set if BUILD_BUFRLIB = "yes"
+CC=gcc
+
+#--------------------------------------------------------------------
+# build BUFRLIB under support:
+# uses F90s and F90_OPT in MACHINE.fortran.sh
+# (generally you should not need to modify below if you use 
+#  Intel or GNU compiler. Otherwise you need to modify below )
+#
+if [ "$BUILD_BUFRLIB" = "yes" ]; then
+   BUILD_DIR=$PWD
+   SUPPORT_DIR="${BUILD_DIR}/../support"
+   BUFR_DIR_NAME="bufr_10.2.3_LE"
+   BUFR_PATH="$SUPPORT_DIR/$BUFR_DIR_NAME"
+   BUFR_URL="https://github.com/cd10kfsu/${BUFR_DIR_NAME}.git"
+   if [ -e $BUFR_PATH/libbufr.a ]; then
+       echo "bufrlib found at: ${SUPPORT_DIR}/libbufr.a"
+   else
+       echo "bufrlib not found at: $SUPPORT_DIR"
+       if [ -d $BUFR_PATH ]; then
+          echo "bufrlib directory found at ($BUFR_PATH) but no libbufs.a: removing this directory"
+          rm -rf $BUFR_PATH
+       fi
+       # clone bufrlibs under support/
+       cd $SUPPORT_DIR && git clone $BUFR_URL
+       cd $BUFR_DIR_NAME
+
+       # setting fortran compiler flags
+       FC=${F90s}
+       if [ "$($FC --version|grep -i 'intel\|ifort'|wc -l)0" -gt 0 ]; then
+          # Intel compiler
+          FC_BUFR_OPT="$F90_OPT -DUNDERSCORE"
+       elif [ "$($FC --version|grep -i 'gnu\|gcc\|gfortran'|wc -l)0" -gt 0 ]; then
+          # GNU compiler
+          FC_BUFR_OPT="$F90_OPT -DUNDERSCORE -fno-second-underscore"
+       else
+          echo "[error] unrecognized Fortran compiler. Exit..."
+          exit 1
+       fi
+
+       # setting C compiler flags
+       if [ "$($CC --version|grep -i 'intel\|icc'|wc -l)0" -gt 0 ]; then
+          # Intel compiler
+          CC_BUFR_OPT="-DUNDERSCORE"
+       elif [ "$($CC --version|grep -i 'gnu\|gcc'|wc -l)0" -gt 0 ]; then
+          # GNU compiler
+          CC_BUFR_OPT="-std=c90 -DUNDERSCORE"
+       else
+          echo "[error] unrecognized C compiler. Exit..."
+          exit 1
+       fi
+
+       # print config
+       echo "======================================="
+       echo "config for building BUFRLIBS"
+       echo "CC=$CC"
+       echo "CC_BUFR_OPT=$CC_BUFR_OPT"
+       echo "FC=$FC"
+       echo "FC_BUFR_OPT=$FC_BUFR_OPT"
+
+       # build libs
+       $CC $CC_BUFR_OPT -c *.c
+       $FC $FC_BUFR_OPT -c *.f
+       ar crv libbufr.a *.o
+   fi
+
+   cd $BUILD_DIR
+
+   BUFR_DIR="$BUFR_PATH"
+   BUFR_LIB="-L$BUFR_DIR/ -lbufr" 
+
+   echo "BUFR_DIR=$BUFR_DIR"
+   echo "BUFR_LIB=$BUFR_LIB"
+
+fi
+

--- a/config/ESSIC.fortran.sh
+++ b/config/ESSIC.fortran.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+F90=mpif90
+F90s="gfortran"   #used to compile BUFRLIBS
+#F90_OPT='-O2 -ffree-form -ffree-line-length-none'
+#STEVE: -mcmodel=medium needed for large model grid sizes (e.g. higher than 1 degree resolution of om3_core3)
+# explanation of -mcmodel=medium and -shared-intel: http://software.intel.com/en-us/forums/showthread.php?t=43717#18089
+#F90_OPT='-O2 -ffree-line-length-none -frecord-marker=4 -finit-local-zero' #CDA: for gfortran version < 10
+F90_OPT='-O2 -ffree-line-length-none -frecord-marker=4 -finit-local-zero -fbacktrace -fcheck=bounds' #CDA: for gfortran version < 10
+F90_OPT="$F90_OPT -fallow-argument-mismatch" #CDA: for gfortran version >= 10
+F90_INLINE=
+F90_DEBUG=
+F90_IEEE= #'-Kieee' #'-fltconsistency'
+F90_OBJECT_FLAG='-c' #STEVE: for some reason, mpxlf doesn't use -c, but rather -g
+BLAS=0
+
+F90_FPP='-cpp'  # for gfortran
+

--- a/config/ESSIC.fortran.sh
+++ b/config/ESSIC.fortran.sh
@@ -6,7 +6,8 @@ F90s="gfortran"   #used to compile BUFRLIBS
 #STEVE: -mcmodel=medium needed for large model grid sizes (e.g. higher than 1 degree resolution of om3_core3)
 # explanation of -mcmodel=medium and -shared-intel: http://software.intel.com/en-us/forums/showthread.php?t=43717#18089
 #F90_OPT='-O2 -ffree-line-length-none -frecord-marker=4 -finit-local-zero' #CDA: for gfortran version < 10
-F90_OPT='-O2 -ffree-line-length-none -frecord-marker=4 -finit-local-zero -fbacktrace -fcheck=bounds' #CDA: for gfortran version < 10
+#F90_OPT='-O2 -ffree-line-length-none -frecord-marker=4 -finit-local-zero -fbacktrace -fcheck=bounds' #CDA: for gfortran version < 10
+F90_OPT='-O2 -ffree-line-length-none -frecord-marker=4 -finit-local-zero -fbacktrace -fcheck=mem,pointer,bounds -fno-realloc-lhs' #CDA: for gfortran version < 10
 F90_OPT="$F90_OPT -fallow-argument-mismatch" #CDA: for gfortran version >= 10
 F90_INLINE=
 F90_DEBUG=

--- a/config/ESSIC.mpi.sh
+++ b/config/ESSIC.mpi.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+MPI_DIR=
+MPI_INC=
+MPI_LIB= #-lmpi

--- a/config/ESSIC.netcdf.sh
+++ b/config/ESSIC.netcdf.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+#NETCDF_DIR=/opt/local
+#NETCDFF_DIR=/opt/local
+#NETCDF_LIB="-L/opt/local/lib -lnetcdff -L/opt/local/lib -Wl,-headerpad_max_install_names -Wl,-syslibroot,/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -arch x86_64 -lnetcdf -lnetcdf -lm"
+#NETCDF_INC="-I/opt/local/include"
+
+#NETCDF_DIR=/opt/local
+#NETCDFF_DIR=/opt/local
+NETCDF_LIB=`nf-config --flibs`
+NETCDF_INC=`nf-config --fflags`
+echo "[$0] NETCDF_LIB=$NETCDF_LIB"
+echo "[$0] NETCDF_INC=$NETCDF_INC"

--- a/config/LOCAL_GFORTRAN.fortran.sh
+++ b/config/LOCAL_GFORTRAN.fortran.sh
@@ -6,8 +6,9 @@ F90s="gfortran"   #used to compile BUFRLIBS
 #STEVE: -mcmodel=medium needed for large model grid sizes (e.g. higher than 1 degree resolution of om3_core3)
 # explanation of -mcmodel=medium and -shared-intel: http://software.intel.com/en-us/forums/showthread.php?t=43717#18089
 #F90_OPT='-O2 -ffree-line-length-none -frecord-marker=4 -finit-local-zero' #CDA: for gfortran version < 10
-F90_OPT='-O2 -ffree-line-length-none -frecord-marker=4 -finit-local-zero -fbacktrace -fcheck=mem,pointer,bounds -fno-realloc-lhs' #CDA: for gfortran version < 10
+F90_OPT="-O2 -ffree-line-length-none -frecord-marker=4 -finit-local-zero -fbacktrace -fcheck=mem,pointer,bounds -fno-realloc-lhs" #CDA: for gfortran version < 10
 F90_OPT="$F90_OPT -fallow-argument-mismatch" #CDA: for gfortran version >= 10
+#F90_OPT="$F90_OPT -fprofile-arcs -ftest-coverage"
 F90_INLINE=
 F90_DEBUG=
 F90_IEEE= #'-Kieee' #'-fltconsistency'

--- a/config/gen_config_template.sh
+++ b/config/gen_config_template.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#
+# generate template for machine config files
+#
+
+if [ $# -ne 1 ]; then
+   echo "$0: Generate template for machine config files"
+   echo "usage: "
+   echo "  $0 CONFIG_FILE_PREFIX"
+   exit 1
+fi
+
+machine=$1
+
+if [ -e flist_LOCAL_GFORTRAN ]; then
+    rm -f flist_LOCAL_GFORTRAN
+fi
+
+ls LOCAL_GFORTRAN.*.sh > flist_LOCAL_GFORTRAN
+while read fname_template; do
+    fend=$(echo $fname_template|cut -d "." -f2-)
+    fname_out="${machine}.${fend}"
+    echo "$fname_out <---------- $fname_template"
+    cp $fname_template $fname_out
+done<flist_LOCAL_GFORTRAN
+
+if [ -e flist_LOCAL_GFORTRAN ]; then
+    rm -f flist_LOCAL_GFORTRAN
+fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,10 @@ set (SRCS
   common_all/kdtree.f90
   common_all/netlib.f
   common_all/netlibblas.f
+# from ../support/io/
+  ../support/io/m_ncio.f90
+  ../support/io/nc_rdatt.f90.inc
+  ../support/io/nc_rdvar.f90.inc
 #--
 # from letkf/
   letkf/params_letkf.f90
@@ -45,10 +49,12 @@ set (SRCS
   model_specific/${MODEL}/common_debug_${MODEL}.f90
 #--
 # from obs/
+  obs/w3movdat_full.f
   obs/params_obs.f90
   obs/compute_profile_error.f90
   obs/read_argo.f90
   obs/read_avhrr_pathfinder.f90
+  obs/read_geostationary.f90
   obs/read_aviso_adt.f90
   obs/read_ice_txt.f90
   obs/gsw_pot_to_insitu.f90
@@ -78,12 +84,15 @@ install(TARGETS OCN.letkf_${MODEL}.x)
 set(operators
   adt
   sst
+  sst_geostationary
   tprof
   sprof
   icefrac
   )
 foreach(operator ${operators})
   add_executable(OCN.obsOp_${MODEL}.${operator}.x obs/obsop_${operator}.f90)
-  target_link_libraries(OCN.obsOp_${MODEL}.${operator}.x PRIVATE OCN.letkf)
+  target_link_libraries(OCN.obsOp_${MODEL}.${operator}.x PRIVATE OCN.letkf NetCDF::NetCDF_Fortran)
+  set_target_properties (OCN.obsOp_${MODEL}.${operator}.x  PROPERTIES Fortran_PREPROCESS ON) 
+  target_compile_definitions(OCN.obsOp_${MODEL}.${operator}.x PRIVATE DYNAMIC)
   install(TARGETS OCN.obsOp_${MODEL}.${operator}.x)
 endforeach()

--- a/src/model_specific/mom6/input_nml_mom6.f90
+++ b/src/model_specific/mom6/input_nml_mom6.f90
@@ -48,7 +48,16 @@ PRIVATE
                               diag_v_name,& !
                               diag_h_name,& !
                               diag_ssh_name,& !
+                              diag_sst_name,& !
+                              diag_sss_name,& !
                               diag_height_name,& !
+                              diag_DO_temp, & !
+                              diag_DO_salt, & !
+                              diag_DO_u, & !
+                              diag_DO_v, & !
+                              diag_DO_ssh, & !
+                              diag_DO_sst, & !
+                              diag_DO_sss, & !
                               rsrt_lon_name,& !
                               rsrt_lat_name,& !
                               rsrt_lev_name,& !

--- a/src/model_specific/mom6/params_model.f90
+++ b/src/model_specific/mom6/params_model.f90
@@ -99,20 +99,22 @@ PUBLIC
   CHARACTER(slen_short) :: grid_height_name = 'col_height'
  
   ! Diagnostic file filenames !STEVE: these aren't used, instead files are specified explicitly by obsop_xxx.f90 routine
-  CHARACTER(11) :: diag_tsbase = 'MOM.diag.nc'   !(and u, and h)
-  CHARACTER(11) :: diag_uvbase = 'MOM.diag.nc'  !(v and ave_ssh/sfc)
+  CHARACTER(slen) :: diag_tsbase = 'MOM.diag.nc'   !(and u, and h)
+  CHARACTER(slen) :: diag_uvbase = 'MOM.diag.nc'  !(v and ave_ssh/sfc)
   CHARACTER(slen) :: diag_hbase
   ! variable names in diag file:
-  CHARACTER(2) :: diag_lon_name = 'xh'
-  CHARACTER(2) :: diag_lat_name = 'yh'
-  CHARACTER(2) :: diag_lev_name = 'zl'
-  CHARACTER(4) :: diag_temp_name = 'temp'
-  CHARACTER(4) :: diag_salt_name = 'salt'
-  CHARACTER(1) :: diag_u_name = 'u'
-  CHARACTER(1) :: diag_v_name = 'v'
-  CHARACTER(1) :: diag_h_name = 'h'
-  CHARACTER(3) :: diag_ssh_name = 'ssh'
-  CHARACTER(10):: diag_height_name = 'col_height'
+  CHARACTER(slen_short) :: diag_lon_name = 'xh'
+  CHARACTER(slen_short) :: diag_lat_name = 'yh'
+  CHARACTER(slen_short) :: diag_lev_name = 'zl'
+  CHARACTER(slen_short) :: diag_temp_name = 'temp'
+  CHARACTER(slen_short) :: diag_salt_name = 'salt'
+  CHARACTER(slen_short) :: diag_u_name = 'u'
+  CHARACTER(slen_short) :: diag_v_name = 'v'
+  CHARACTER(slen_short) :: diag_h_name = 'h'
+  CHARACTER(slen_short) :: diag_ssh_name = 'ssh'
+  CHARACTER(slen_short) :: diag_sst_name = 'sst'
+  CHARACTER(slen_short) :: diag_sss_name = 'sss'
+  CHARACTER(slen_short) :: diag_height_name = 'col_height'
 
   !STEVE: flags to specify whether to read in each variable
   !       only the observed variables are needed from the diag file
@@ -121,6 +123,8 @@ PUBLIC
   LOGICAL :: diag_DO_u    = .false.
   LOGICAL :: diag_DO_v    = .false.
   LOGICAL :: diag_DO_ssh  = .true.
+  LOGICAL :: diag_DO_sst  = .true.
+  LOGICAL :: diag_DO_sss  = .true.
 
   ! Restart filenames
   CHARACTER(10) :: rsrt_tsbase = 'MOM.res.nc'   !(and u, and h)

--- a/src/obs/obsop_sst_geostationary.f90
+++ b/src/obs/obsop_sst_geostationary.f90
@@ -105,8 +105,6 @@ PROGRAM obsop_sst_acspo
   !-----------------------------------------------------------------------------
   CALL read_geostationary_nc(trim(obsinfile), trim(navinfile), min_quality_level, obs_data, nobs)
 
-  STOP "cda: finish reading"
-
   ALLOCATE( elem(nobs) )
   ALLOCATE( rlon(nobs) )
   ALLOCATE( rlat(nobs) )

--- a/src/obs/obsop_sst_geostationary.f90
+++ b/src/obs/obsop_sst_geostationary.f90
@@ -7,7 +7,7 @@ PROGRAM obsop_sst_acspo
   USE params_obs,                ONLY: DO_REMOVE_65N
   USE vars_obs
   USE common_obs_oceanmodel
-  USE read_abi_acspo,     ONLY: read_abi_acspo_nc, abi_acspo_data
+  USE read_geostationary,     ONLY: read_geostationary_nc, sst_geostationary_data
 #ifdef DYNAMIC
   USE input_nml_oceanmodel,      ONLY: read_input_namelist
 #endif
@@ -27,7 +27,7 @@ PROGRAM obsop_sst_acspo
   !-----------------------------------------------------------------------------
   ! Obs data arrays
   !-----------------------------------------------------------------------------
-  TYPE(abi_acspo_data), ALLOCATABLE :: obs_data(:)
+  TYPE(sst_geostationary_data), ALLOCATABLE :: obs_data(:)
 
   REAL(r_size), ALLOCATABLE :: elem(:)
   REAL(r_size), ALLOCATABLE :: rlon(:)
@@ -103,7 +103,7 @@ PROGRAM obsop_sst_acspo
   !-----------------------------------------------------------------------------
   ! Read observations from file
   !-----------------------------------------------------------------------------
-  CALL read_abi_acspo_nc(trim(obsinfile), trim(navinfile), min_quality_level, obs_data, nobs)
+  CALL read_geostationary_nc(trim(obsinfile), trim(navinfile), min_quality_level, obs_data, nobs)
 
   STOP "cda: finish reading"
 

--- a/src/obs/obsop_sst_podaac.f90
+++ b/src/obs/obsop_sst_podaac.f90
@@ -1,0 +1,500 @@
+PROGRAM obsop_sst_podaac
+!===============================================================================
+! PROGRAM: obsop_sst
+! 
+! USES:
+!  use common
+!  use params_model
+!  use vars_model
+!  use common_oceanmodel
+!  use params_obs
+!  use vars_obs
+!  use common_obs_oceanmodel
+!
+!
+! DESCRIPTION: 
+!   This program acts as the observation operator. It inputs observations (yo)
+!   and a single forecast (xf) and computes the innovations (yo-H(xf))
+!   associated with that member.
+!
+! USAGE:
+! A separate instance is run independently for each member and timeslot
+! All observations are typically preprocessed to the letkf obs format, then
+! here they are read in and converted to the letkf obs2 format w/ H(x) data 
+! for each member added in a new column.
+! 
+! !REVISION HISTORY:
+!   04/03/2014 Steve Penny modified for use with OCEAN at NCEP.
+!   04/03/2013 Takemasa Miyoshi created for SPEEDY atmospheric model.
+! 
+!-------------------------------------------------------------------------------
+! $Author: Steve Penny, Takemasa Miyoshi $
+!===============================================================================
+
+  USE common
+  USE params_model
+  USE vars_model
+  USE common_oceanmodel
+  USE params_obs,                ONLY: nobs, id_sst_obs
+  USE params_obs,                ONLY: DO_REMOVE_65N
+  USE vars_obs
+  USE common_obs_oceanmodel
+  USE read_avhrr_pathfinder,     ONLY: read_avhrr_pathfinder_nc, obs_data
+#ifdef DYNAMIC
+  USE input_nml_oceanmodel,      ONLY: read_input_namelist
+#endif
+
+  IMPLICIT NONE
+
+  !-----------------------------------------------------------------------------
+  ! Command line inputs:
+  !-----------------------------------------------------------------------------
+  CHARACTER(slen) :: obsinfile='obsin.nc'     !IN (default)
+  CHARACTER(slen) :: guesfile='gues'          !IN (default) i.e. prefix to '.ocean_temp_salt.res.nc'
+  CHARACTER(slen) :: obsoutfile='obsout.dat'  !OUT(default)
+  REAL(r_size) :: obserr_scaling=1.0d0 !STEVE: use this to scale the input observations
+  REAL(r_size) :: obs_randselect=1.0d0 !STEVE: use this to select random input observations
+
+  !-----------------------------------------------------------------------------
+  ! Obs data arrays
+  !-----------------------------------------------------------------------------
+  REAL(r_size), ALLOCATABLE :: elem(:)
+  REAL(r_size), ALLOCATABLE :: rlon(:)
+  REAL(r_size), ALLOCATABLE :: rlat(:)
+  REAL(r_size), ALLOCATABLE :: rlev(:)
+  REAL(r_size), ALLOCATABLE :: odat(:)
+  REAL(r_size), ALLOCATABLE :: oerr(:)
+  REAL(r_size), ALLOCATABLE :: ohx(:)
+  REAL(r_size), ALLOCATABLE :: obhr(:)
+  INTEGER     , ALLOCATABLE :: oqc(:)
+
+  !-----------------------------------------------------------------------------
+  ! Model background data arrays
+  !-----------------------------------------------------------------------------
+  REAL(r_size), ALLOCATABLE :: v3d(:,:,:,:)
+  REAL(r_size), ALLOCATABLE :: v2d(:,:,:)
+
+  !-----------------------------------------------------------------------------
+  ! Miscellaneous
+  !-----------------------------------------------------------------------------
+  REAL(r_size) :: dk,tg,qg
+  REAL(r_size) :: ri,rj,rk
+  INTEGER :: n, i,j,k
+  REAL(r_size), DIMENSION(1) :: rand
+  
+  LOGICAL :: remap_obs_coords = .true.
+
+  INTEGER :: bdyobs=2                 !STEVE: use of boundary obs.
+                                      !       1 := less restrictive, remove obs inside boundary
+                                      !       2 := remove all observations touching a boundary
+
+  !-----------------------------------------------------------------------------
+  ! Debugging parameters
+  !-----------------------------------------------------------------------------
+  LOGICAL :: debug_obsfilter = .false.
+  !STEVE: to adjust writing to output file
+  LOGICAL :: verbose = .false.
+  LOGICAL :: dodebug1 = .false.
+  LOGICAL :: print1st = .true.
+
+  INTEGER :: cnt_obs_u=0, cnt_obs_v=0, cnt_obs_t=0, cnt_obs_s=0
+  INTEGER :: cnt_obs_ssh=0, cnt_obs_sst=0, cnt_obs_sss=0, cnt_obs_eta=0
+  INTEGER :: cnt_obs_x=0, cnt_obs_y=0, cnt_obs_z=0
+  INTEGER, DIMENSION(nv3d+nv2d), SAVE :: cnt_obs = 0
+
+  !STEVE: for debugging observation culling:
+  INTEGER :: cnt_yout=0, cnt_xout=0, cnt_zout=0, cnt_triout=0
+  INTEGER :: cnt_rigtnlon=0, cnt_nearland=0, cnt_oerlt0=0, cnt_altlatrng=0
+
+  !-----------------------------------------------------------------------------
+  ! Instantiations specific to this observation type:
+  !-----------------------------------------------------------------------------
+  INTEGER :: min_quality_level=4  !STEVE: (default) for AVHRR
+  INTEGER :: typ = id_sst_obs
+  LOGICAL :: DO_SUPEROBS = .false.
+  REAL(r_size), DIMENSION(:,:), ALLOCATABLE :: superobs, delta, M2 ! for online computation of the mean and variance
+  INTEGER, DIMENSION(:,:), ALLOCATABLE :: supercnt
+  INTEGER :: idx
+  INTEGER :: cnt_obs_thinning = 0
+  REAL(r_size) :: min_oerr = 1.0 !ÂC !ÂC
+
+  !-----------------------------------------------------------------------------
+  ! Initialize the common_oceanmodel module, and process command line options
+  !-----------------------------------------------------------------------------
+#ifdef DYNAMIC
+  CALL read_input_namelist
+#endif
+  CALL set_common_oceanmodel
+  CALL process_command_line !(get: -obsin <obsinfile> -gues <guesfile> -obsout <obsoutfile>)
+
+  ALLOCATE(superobs(nlon,nlat),delta(nlon,nlat),M2(nlon,nlat),supercnt(nlon,nlat))
+
+  !-----------------------------------------------------------------------------
+  ! Read observations from file
+  !-----------------------------------------------------------------------------
+  CALL read_avhrr_pathfinder_nc(obsinfile,typ,min_quality_level,obs_data,nobs)
+  ALLOCATE( elem(nobs) )
+  ALLOCATE( rlon(nobs) )
+  ALLOCATE( rlat(nobs) )
+  ALLOCATE( rlev(nobs) )
+  ALLOCATE( odat(nobs) )
+  ALLOCATE( oerr(nobs) )
+  ALLOCATE( ohx(nobs) )
+  ALLOCATE( oqc(nobs) )
+  ALLOCATE( obhr(nobs) )
+
+  print *, "obsop_sst.f90:: starting nobs = ", nobs
+  do i=1,nobs
+    elem(i) = obs_data(i)%typ
+    rlon(i) = obs_data(i)%x_grd(1)
+    rlat(i) = obs_data(i)%x_grd(2)
+!   rlev(i) = obs_data(i)%x_grd(3) !STEVE: not applicable for SST
+    odat(i) = obs_data(i)%value
+    oerr(i) = obs_data(i)%oerr
+    ohx(i)  = 0
+    oqc(i)  = 0
+    obhr(i) = obs_data(i)%hour
+  enddo
+  DEALLOCATE(obs_data)
+
+  if (print1st) then  
+    print *, "elem(1),rlon(1),rlat(1),obhr(1) = ", elem(1),rlon(1),rlat(1),obhr(1)
+    print *, "odat(1:40) = ", odat(1:40)
+    print *, "oerr(1:40) = ", oerr(1:40)
+  endif
+
+  !-----------------------------------------------------------------------------
+  ! Update the coordinate to match the model grid
+  !-----------------------------------------------------------------------------
+  if (remap_obs_coords) then
+    CALL center_obs_coords(rlon,oerr,nobs)
+  endif
+
+  !-----------------------------------------------------------------------------
+  ! Bin the obs and estimate the obs error based on bin standard deviations
+  !-----------------------------------------------------------------------------
+  if (DO_SUPEROBS) then
+    print *, "Computing superobs..."
+    supercnt = 0
+    superobs = 0.0d0
+
+    !STEVE: (ISSUE) this may have problems in the arctic for the tripolar grid,
+    !               or for any irregular grid in general.
+    do n=1,nobs ! for each ob,
+!     if (dodebug1) print *, "n = ", n
+      ! Scan the longitudes
+      do i=1,nlon-1
+        if (lon(i+1) > rlon(n)) exit
+      enddo
+      ! Scan the latitudes
+      do j=1,nlat-1
+        if (lat(j+1) > rlat(n)) exit 
+      enddo
+
+      supercnt(i,j) = supercnt(i,j) + 1
+      delta(i,j) = odat(n) - superobs(i,j)
+      superobs(i,j) = superobs(i,j) + delta(i,j)/supercnt(i,j)
+      M2(i,j) = M2(i,j) + delta(i,j)*(odat(n) - superobs(i,j))
+!     if (dodebug1) print *, "supercnt(",i,",",j,") = ", supercnt(i,j)
+    enddo
+    !"superobs" contains the mean
+    !M2 contains the variance:
+    WHERE(supercnt > 1) M2 = M2 / (supercnt - 1)
+
+    idx=0
+    do j=1,nlat-1
+      do i=1,nlon-1
+        if (supercnt(i,j) > 1) then
+          idx = idx+1
+          if (dodebug1) print *, "idx = ", idx
+          odat(idx) = superobs(i,j)
+          oerr(idx) = obserr_scaling*(min_oerr + SQRT(M2(i,j)))
+          rlon(idx) = (lon(i+1)+lon(i))/2.0d0
+          rlat(idx) = (lat(j+1)+lat(j))/2.0d0
+          rlev(idx) = 0
+          elem(idx) = id_sst_obs
+          if (dodebug1) print *, "odat(idx) = ", odat(idx)
+          if (dodebug1) print *, "oerr(idx) = ", oerr(idx)
+          if (dodebug1) print *, "rlon(idx) = ", rlon(idx)
+          if (dodebug1) print *, "rlat(idx) = ", rlat(idx)
+          if (dodebug1) print *, "ocnt(idx) = ", supercnt(i,j)
+        endif
+      enddo
+    enddo
+    print *, "DO_SUPEROBS:: superobs reducing from ",nobs," to ",idx, " observations." 
+    print *, "with min obs error = ", MINVAL(oerr(1:idx))
+    print *, "with max obs error = ", MAXVAL(oerr(1:idx))
+    nobs = idx
+  endif
+
+  !-----------------------------------------------------------------------------
+  ! Read model forecast for this member
+  !-----------------------------------------------------------------------------
+  ALLOCATE( v3d(nlon,nlat,nlev,nv3d) )
+  ALLOCATE( v2d(nlon,nlat,nv2d) )
+  !STEVE: (ISSUE) this can be improved by only reading in the file for needed for this data.
+  CALL read_diag(guesfile,v3d,v2d)
+  WRITE(6,*) '****************'
+
+  !-----------------------------------------------------------------------------
+  ! Cycle through all observations
+  !-----------------------------------------------------------------------------
+  WRITE(6,*) "Cycling through observations..."
+
+  ohx=0.0d0
+  oqc=0
+  idx=0
+  DO n=1,nobs
+    ! Thin observations
+    ! Select random subset of observations to speed up processing
+    !STEVE: I know this would be more efficient up above when obs are first introduced.
+    thin : if (obs_randselect < 1.0d0) then
+      CALL com_rand(1,rand)
+      if (rand(1) > obs_randselect) then
+        cnt_obs_thinning = cnt_obs_thinning + 1
+        CYCLE
+      endif
+    endif thin
+
+    !---------------------------------------------------------------------------
+    ! Count bad obs errors associated with observations, and skip the ob
+    !---------------------------------------------------------------------------
+    if (oerr(n) <= 0) then
+      !STEVE: this occurred for a few synthetic obs, perhaps due to Dave's code generating obs errors
+      cnt_oerlt0 = cnt_oerlt0 + 1
+      CYCLE
+    endif
+
+    !---------------------------------------------------------------------------
+    ! Convert the physical coordinate to model grid coordinate (note: real, not integer)
+    !---------------------------------------------------------------------------
+    CALL phys2ijk(elem(n),rlon(n),rlat(n),rlev(n),ri,rj,rk) !(OCEAN)
+   
+    !---------------------------------------------------------------------------
+    ! Filter in the tripolar region until localization is examined in the arctic !(ISSUE)
+    !---------------------------------------------------------------------------
+    if (DO_REMOVE_65N .and. rlat(n) > 65) then
+      if (verbose) WRITE(6,'(A)') "Latitude above 65.0N, in tripolar region. Removing observation..."
+      cnt_triout = cnt_triout + 1
+      CYCLE
+    endif
+
+    !---------------------------------------------------------------------------
+    ! Filter out observations that are out of range for the grid
+    !---------------------------------------------------------------------------
+    if (CEILING(ri) < 2 .OR. nlon+1 < CEILING(ri)) then
+      if (verbose) WRITE(6,'(A)') '* X-coordinate out of range'
+      if (verbose) WRITE(6,'(A,F6.2,A,F6.2)') '*   ri=',ri,', olon=', rlon(n)
+      cnt_xout = cnt_xout + 1
+      CYCLE
+    endif
+    if (CEILING(rj) < 2 .OR. nlat < CEILING(rj)) then
+      if (verbose) WRITE(6,'(A)') '* Y-coordinate out of range'
+      if (verbose) WRITE(6,'(A,F6.2,A,F6.2)') '*   rj=',rj,', olat=',rlat(n)
+      cnt_yout = cnt_yout + 1
+      CYCLE
+    endif
+    !STEVE: check against kmt, not nlev (OCEAN)
+    if (CEILING(rk) > nlev) then
+      CALL itpl_2d(kmt0,ri,rj,dk)
+      WRITE(6,'(A)') '* Z-coordinate out of range'
+      WRITE(6,'(A,F6.2,A,F10.2,A,F6.2,A,F6.2,A,F10.2)') &
+           & '*   rk=',rk,', olev=',rlev(n),&
+           & ', (lon,lat)=(',rlon(n),',',rlat(n),'), kmt0=',dk
+      cnt_zout = cnt_zout + 1
+      CYCLE
+    endif
+    if (CEILING(rk) < 2 .AND. rk < 1.00001d0) then   !(OCEAN)
+      rk = 1.00001d0                                 !(OCEAN)
+    endif                                            !(OCEAN)
+
+    !---------------------------------------------------------------------------
+    ! Check the observation against boundaries
+    !---------------------------------------------------------------------------
+    !STEVE: Check to make sure it's in the ocean, as determined       (OCEAN)
+    !       by mom4's topography map.
+    ! (note: must do it after coordinate checks, or the coordinate
+    !        could be outside of the range of the kmt array)
+    boundary_points : if (ri > nlon) then
+      !STEVE: I have to check what it does for this case...
+      !       but it causes an error in the next line if ri > nlon
+      if (verbose) WRITE(6,'(A)') '* coordinate is not on mom4 model grid: ri > nlon'
+      cnt_rigtnlon = cnt_rigtnlon + 1
+      if (cnt_rigtnlon <= 1) then
+        WRITE(6,*) "STEVE: ri > nlon (cnt_rigtnlon)"
+        WRITE(6,*) "ri = ", ri
+        WRITE(6,*) "nlon = ", nlon
+        WRITE(6,*) "rj = ", rj
+        WRITE(6,*) "elem(n) = ", elem(n)
+        WRITE(6,*) "rlon(n) = ", rlon(n)
+        WRITE(6,*) "rlat(n) = ", rlat(n)
+        WRITE(6,*) "rlev(n) = ", rlev(n)
+        WRITE(6,*) "rk = ", rk
+      endif
+      CYCLE
+    else
+      !STEVE: check this, case 1 allows more observations, case 2 is more restrictive
+      select case (bdyobs)
+      case(1)
+        if (kmt(NINT(ri),NINT(rj)) .lt. 1) then
+          if (debug_obsfilter) then
+            WRITE(6,'(A)') '* coordinate is on or too close to land, according to kmt'
+            WRITE(6,'(A,F6.2,A,F6.2)') '*   ri=',ri,', rj=',rj
+            WRITE(6,*) "kmt cell = ", kmt(NINT(ri),NINT(rj))
+          endif
+          cnt_nearland = cnt_nearland + 1
+          CYCLE
+        elseif (kmt(NINT(ri),NINT(rj)) .lt. rk) then
+          if (debug_obsfilter) then
+            WRITE(6,'(A)') '* coordinate is on or too close to underwater topography, according to kmt'
+            WRITE(6,'(A,F6.2,A,F6.2,A,F6.2)') '*   ri=',ri,', rj=',rj, ', rk=',rk
+            WRITE(6,*) "kmt cell = ", kmt(NINT(ri),NINT(rj))
+          endif
+          cnt_nearland = cnt_nearland + 1
+          CYCLE
+        endif
+      case(2)
+        if(kmt(CEILING(ri),CEILING(rj)) .lt. 1 .or. &
+             kmt(CEILING(ri),FLOOR(rj)) .lt. 1 .or. &
+             kmt(FLOOR(ri),CEILING(rj)) .lt. 1 .or. &
+             kmt(FLOOR(ri),FLOOR(rj)) .lt. 1) THEN
+
+          if (debug_obsfilter) then
+            WRITE(6,'(A)') '* coordinate is too close to land, according to kmt'
+            WRITE(6,'(A,F6.2,A,F6.2)') '*   ri=',ri,', rj=',rj
+            WRITE(6,*) "kmt cell = ", kmt(FLOOR(ri):CEILING(ri),FLOOR(rj):CEILING(rj))
+          endif
+          cnt_nearland = cnt_nearland + 1
+          CYCLE
+        elseif(kmt(CEILING(ri),CEILING(rj)) .lt. rk .or. &
+                  kmt(CEILING(ri),FLOOR(rj)) .lt. rk .or. &
+                  kmt(FLOOR(ri),CEILING(rj)) .lt. rk .or. &
+                  kmt(FLOOR(ri),FLOOR(rj)) .lt. rk) THEN
+
+          if (debug_obsfilter) then
+            WRITE(6,'(A)') '* coordinate is too close to underwater topography, according to kmt'
+            WRITE(6,'(A,F6.2,A,F6.2,A,F6.2)') '*   ri=',ri,', rj=',rj, ', rk=',rk
+            WRITE(6,*) "kmt cell = ", kmt(FLOOR(ri):CEILING(ri),FLOOR(rj):CEILING(rj))
+          endif
+          cnt_nearland = cnt_nearland + 1
+          CYCLE
+        endif
+      end select
+    endif boundary_points
+        
+    !---------------------------------------------------------------------------
+    ! observation operator (computes H(x)) for specified member
+    !---------------------------------------------------------------------------
+    CALL Trans_XtoY(elem(n),ri,rj,rk,v3d,v2d,ohx(n))
+    idx=idx+1
+    oqc(n) = 1
+  enddo !1:nobs
+
+  !-----------------------------------------------------------------------------
+  ! Print out the counts of observations removed for various reasons
+  !-----------------------------------------------------------------------------
+  WRITE(6,*) "In obsop_sst.f90::"
+  WRITE(6,*) "observations at start = ", nobs
+  WRITE(6,*) "== observations removed for: =="
+  WRITE(6,*) "cnt_obs_thinning = ", cnt_obs_thinning
+  WRITE(6,*) "cnt_oerlt0 = ", cnt_oerlt0
+  WRITE(6,*) "cnt_xout = ", cnt_xout
+  WRITE(6,*) "cnt_yout = ", cnt_yout
+  WRITE(6,*) "cnt_zout = ", cnt_zout
+  WRITE(6,*) "cnt_triout = ", cnt_triout
+  WRITE(6,*) "cnt_rigtnlon = ", cnt_rigtnlon
+  WRITE(6,*) "cnt_nearland = ", cnt_nearland
+  WRITE(6,*) "cnt_altlatrng = ", cnt_altlatrng
+  WRITE(6,*) "==============================="
+  WRITE(6,*) "observations kept = ", idx
+  WRITE(6,*) "==============================="
+
+  !-----------------------------------------------------------------------------
+  ! Write the observations and their associated innovations to file
+  !-----------------------------------------------------------------------------
+  CALL write_obs2(obsoutfile,nobs,elem,rlon,rlat,rlev,odat,oerr,ohx,oqc,obhr)
+
+  DEALLOCATE( elem,rlon,rlat,rlev,odat,oerr,ohx,oqc,obhr,v3d,v2d )
+
+CONTAINS
+
+SUBROUTINE process_command_line
+!===============================================================================
+! Process command line arguments 
+!===============================================================================
+IMPLICIT NONE
+INTEGER, PARAMETER :: slen2=1024
+CHARACTER(slen2) :: arg1,arg2
+INTEGER :: i, ierr
+INTEGER, DIMENSION(3) :: values
+
+! STEVE: add input error handling!
+! inputs are in the format "-x xxx"
+do i=1,COMMAND_ARGUMENT_COUNT(),2
+  CALL GET_COMMAND_ARGUMENT(i,arg1)
+  PRINT *, "In obsop_sst.f90::"
+  PRINT *, "Argument ", i, " = ",TRIM(arg1)
+
+  select case (arg1)
+!   case('-nlon')
+!     CALL GET_COMMAND_ARGUMENT(i+1,arg2)
+!     PRINT *, "Argument ", i+1, " = ",TRIM(arg2)
+!     read (arg2,*) nlon
+!   case('-nlat')
+!     CALL GET_COMMAND_ARGUMENT(i+1,arg2)
+!     PRINT *, "Argument ", i+1, " = ",TRIM(arg2)
+!     read (arg2,*) nlat
+!   case('-nlev')
+!     CALL GET_COMMAND_ARGUMENT(i+1,arg2)
+!     PRINT *, "Argument ", i+1, " = ",TRIM(arg2)
+!     read (arg2,*) nlev
+    case('-obsin')
+      CALL GET_COMMAND_ARGUMENT(i+1,arg2)
+      PRINT *, "Argument ", i+1, " = ",TRIM(arg2)
+      obsinfile = arg2
+    case('-gues')
+      CALL GET_COMMAND_ARGUMENT(i+1,arg2)
+      PRINT *, "Argument ", i+1, " = ",TRIM(arg2)
+      guesfile = arg2
+    case('-obsout')
+      CALL GET_COMMAND_ARGUMENT(i+1,arg2)
+      PRINT *, "Argument ", i+1, " = ",TRIM(arg2)
+      obsoutfile = arg2
+    case('-rm65N')
+      CALL GET_COMMAND_ARGUMENT(i+1,arg2)
+      PRINT *, "Argument ", i+1, " = ",TRIM(arg2)
+      read (arg2,*) DO_REMOVE_65N
+    case('-superob')
+      CALL GET_COMMAND_ARGUMENT(i+1,arg2)
+      PRINT *, "Argument ", i+1, " = ",TRIM(arg2)
+      read (arg2,*) DO_SUPEROBS
+    case('-thin')
+      CALL GET_COMMAND_ARGUMENT(i+1,arg2)
+      PRINT *, "Argument ", i+1, " = ",TRIM(arg2)
+      read (arg2,*) obs_randselect
+    case('-scale')
+      CALL GET_COMMAND_ARGUMENT(i+1,arg2)
+      PRINT *, "Argument ", i+1, " = ",TRIM(arg2)
+      read (arg2,*) obserr_scaling
+    case('-minerr')
+      CALL GET_COMMAND_ARGUMENT(i+1,arg2)
+      PRINT *, "Argument ", i+1, " = ",TRIM(arg2)
+      read (arg2,*) min_oerr
+    case('-minqc')
+      CALL GET_COMMAND_ARGUMENT(i+1,arg2)
+      PRINT *, "Argument ", i+1, " = ",TRIM(arg2)
+      read (arg2,*) min_quality_level
+    case('-debug')
+      CALL GET_COMMAND_ARGUMENT(i+1,arg2)
+      PRINT *, "Argument ", i+1, " = ",TRIM(arg2)
+      read (arg2,*) dodebug1
+    case default
+      PRINT *, "ERROR: option is not supported: ", arg1
+      PRINT *, "(with value : ", trim(arg2), " )"
+      stop 1
+  end select
+enddo
+
+END SUBROUTINE process_command_line
+
+END PROGRAM obsop_sst_podaac

--- a/src/obs/read_abi_acspo.f90
+++ b/src/obs/read_abi_acspo.f90
@@ -1,0 +1,225 @@
+MODULE read_abi_acspo
+  USE common,       ONLY: r_sngl, r_dble, r_size
+  USE params_obs,   ONLY: id_sst_obs
+  IMPLICIT NONE
+
+  PRIVATE
+
+  PUBLIC :: abi_acspo_data
+  PUBLIC :: read_abi_acspo_nc
+  PRIVATE :: inspect_obs_data
+
+  TYPE abi_acspo_data
+    REAL(r_size) :: x_grd(2)  ! longitude, latitude
+    REAL(r_size) :: value     ! actual physical value of the parameter measured at this grid point
+    REAL(r_size) :: oerr      ! observation standard error
+    REAL(r_size) :: hour      ! Hour of observation
+    INTEGER :: qkey           ! Quality key
+    INTEGER :: typ            ! type of observation (elem)
+    LOGICAL :: kept           ! tells letkf whether this obs is kept for assimilation
+  END TYPE abi_acspo_data
+
+CONTAINS
+
+SUBROUTINE read_abi_acspo_nc(obsinfile, navinfile, min_quality_level, obs_data, nobs)
+  USE m_ncio,     ONLY: nc_get_fid, nc_close_fid, nc_rddim, nc_rdvar2d, nc_rdvar1d, &
+                        nc_rdatt
+  IMPLICIT NONE
+
+  CHARACTER(*),INTENT(IN) :: obsinfile               
+  CHARACTER(*),INTENT(IN) :: navinfile
+  INTEGER,     INTENT(IN) :: min_quality_level
+  TYPE(abi_acspo_data),ALLOCATABLE,INTENT(INOUT) :: obs_data(:)
+  INTEGER,     INTENT(OUT) :: nobs
+
+  INTEGER :: fid, ni, nj, i, j, n, qlev
+
+  REAL(r_size),ALLOCATABLE :: alon2d(:,:), alat2d(:,:)
+  REAL(r_size),ALLOCATABLE :: sea_surface_temperature(:,:), stde(:,:), sst_dtime(:,:)
+  INTEGER(4),  ALLOCATABLE :: quality_level(:,:)
+  INTEGER(1),  ALLOCATABLE :: i1buf2d(:,:)
+  INTEGER(2),  ALLOCATABLE :: i2buf2d(:,:)
+  LOGICAL,     ALLOCATABLE :: valid(:,:) ! .TRUE. if no missing info at this grid by checking different FillValues in nc file
+  INTEGER :: FillValue ! missing value indicated by vars in nc file
+  REAL(r_size) :: offset, scale_factor
+  LOGICAL :: dodebug = .TRUE.
+  INTEGER :: obsdate(8), sdate(8)
+  REAL :: tdelta(5)
+  INTEGER :: time(1)
+
+!-------------------------------------------------------------------------------
+! Read dimension & geo info from navigation file (navinfile)
+!-------------------------------------------------------------------------------
+  CALL nc_get_fid(trim(navinfile),fid)
+  CALL nc_rddim(fid,"ni", ni)
+  print *, "**************************"
+  print *, "ni dimension is = ", ni
+  print *, "**************************"
+
+  CALL nc_rddim(fid,"nj", nj)
+  print *, "**************************"
+  print *, "nj dimension is = ", nj
+  print *, "**************************"
+
+  ALLOCATE(alon2d(ni,nj),alat2d(ni,nj))
+  ALLOCATE(valid(ni,nj))
+  valid = .TRUE.
+  CALL nc_rdvar2d(fid,"lon",alon2d)
+  WRITE(6,*) "[msg] read_abi_acspo_nc::alon2d: min, max=", &
+             minval(alon2d),maxval(alon2d)
+  CALL nc_rdvar2d(fid,"lat",alat2d)
+  WRITE(6,*) "[msg] read_abi_acspo_nc::alat2d: min, max=", &
+             minval(alat2d),maxval(alat2d)
+  CALL nc_close_fid(fid)
+
+!-------------------------------------------------------------------------------
+! Read retrieved SST and other info from obs file (obsinfile)
+!-------------------------------------------------------------------------------
+  CALL nc_get_fid(trim(obsinfile),fid)
+
+  ALLOCATE(i1buf2d(ni,nj))
+  ALLOCATE(i2buf2d(ni,nj))
+
+! SST
+  CALL nc_rdvar2d(fid, "sea_surface_temperature", i2buf2d)
+  CALL nc_rdatt(fid, "sea_surface_temperature","scale_factor", scale_factor)
+  CALL nc_rdatt(fid, "sea_surface_temperature","add_offset", offset)
+  CALL nc_rdatt(fid, "sea_surface_temperature","_FillValue", FillValue)
+  if (dodebug) WRITE(6,*) "_FillValue, scale_factor, add_offset=", &
+               FillValue, scale_factor, offset
+  where (i2buf2d == FillValue)
+      valid = .FALSE.
+  end where
+  ALLOCATE(sea_surface_temperature(ni,nj))
+  sea_surface_temperature = REAL(i2buf2d,r_size)*scale_factor + offset
+  WRITE(6,*) "[msg] read_abi_acspo_nc::sst: min, max=", &
+             minval(sea_surface_temperature), maxval(sea_surface_temperature), &
+             minval(sea_surface_temperature, mask=valid),&
+             maxval(sea_surface_temperature, mask=valid)
+
+! SST error
+  CALL nc_rdvar2d(fid, "sses_standard_deviation", i1buf2d)
+  CALL nc_rdatt(fid, "sses_standard_deviation", "scale_factor", scale_factor)
+  CALL nc_rdatt(fid, "sses_standard_deviation", "add_offset", offset)
+  CALL nc_rdatt(fid, "sses_standard_deviation", "_FillValue", FillValue)
+  if (dodebug) WRITE(6,*) "_FillValue, scale_factor, add_offset=", &
+               FillValue, scale_factor, offset
+  where (i1buf2d == FillValue)
+     valid = .FALSE.
+  end where
+  ALLOCATE(stde(ni,nj))
+  stde = REAL(i1buf2d,r_size)*scale_factor + offset
+  WRITE(6,*) "[msg] read_abi_acspo_nc::stde: min, max=", &
+             minval(stde), maxval(stde), &
+             minval(stde, mask=valid),maxval(stde, mask=valid)
+
+! sst_time
+  CALL nc_rdvar1d(fid, "time", time)
+  WRITE(6,*) "[msg] read_abi_acspo_nc::time=",time(1)
+  sdate = [1981, 1, 1, 0, 0, 0, 0, 0] ! YYYY/MON/DAY/TZONE/HR/MIN/SEC/MSEC
+  tdelta = [0.0,0.0,0.0,REAL(time(1)),0.0] ! DAY/HR/MIN/SEC/MSEC
+  CALL w3movdat(tdelta, sdate, obsdate)
+  WRITE(6,*) "[msg] read_abi_acspo_nc::obstime=", obsdate(1:3),obsdate(5:7)
+
+! sst_dtime
+  CALL nc_rdvar2d(fid, "sst_dtime", i2buf2d)
+  CALL nc_rdatt(fid, "sst_dtime", "scale_factor", scale_factor)
+  CALL nc_rdatt(fid, "sst_dtime", "add_offset", offset)
+  CALL nc_rdatt(fid, "sst_dtime", "_FillValue", FillValue)
+  if (dodebug) WRITE(6,*) "_FillValue, scale_factor, add_offset=", &
+               FillValue, scale_factor, offset
+  where (i2buf2d == FillValue)
+     valid = .FALSE.
+  end where
+  ALLOCATE(sst_dtime(ni,nj))
+  sst_dtime = REAL(i2buf2d,r_size)*scale_factor + offset
+  WRITE(6,*) "[msg] read_abi_acspo_nc::sst_dtime: min, max=", &
+             minval(sst_dtime), maxval(sst_dtime), &
+             minval(sst_dtime, mask=valid),maxval(sst_dtime, mask=valid)
+
+! Quality key (5-best, 4, 3, 2, 1, 0-worst)
+  ALLOCATE(quality_level(ni,nj))
+  CALL nc_rdvar2d(fid, "quality_level", quality_level)
+  CALL nc_rdatt(fid, "quality_level", "_FillValue", FillValue)
+  if (dodebug) then
+     WRITE(6,*) "_FillValue=", FillValue
+     ! check num of obs for each quality level
+     do i = -1, 5
+        i1buf2d = 0
+        if (i==-1) then
+           qlev = FillValue 
+        else
+           qlev = i
+        end if
+        where (quality_level == qlev)
+            i1buf2d = 1
+        end where
+        n = sum(int(i1buf2d,4))
+        WRITE(6,*) "[msg] read_abi_acspo_nc::quality_level, # of obs, %=", i, n, n*100.0/(ni*nj)
+     end do
+  end if
+  where (quality_level == FillValue)
+      valid = .FALSE.
+  end where
+  !WRITE(6,*) "[msg] read_abi_acspo_nc::quality_level: min, max=", &
+  !           minval(quality_level, mask=valid), maxval(quality_level, mask=valid)
+  
+! Close file
+  CALL nc_close_fid(fid)
+
+!-------------------------------------------------------------------------------
+! CONVERT netcdf data to argo_data format:
+!-------------------------------------------------------------------------------
+  WRITE(6,*) "Finished reading netCDF file, formatting data..."
+
+! determine num of valid obs
+  WRITE(6,*) "[msg] read_abi_acspo_nc::use obs with min_quality_level=", min_quality_level
+  nobs = 0
+  do j = 1, nj; do i = 1, ni
+    if (quality_level(i,j) >= min_quality_level.and.valid(i,j)) then
+       nobs = nobs + 1
+    end if
+  end do; end do
+  WRITE(6,*) "[msg] read_abi_acspo_nc::nobs_retained, %=", nobs, nobs*100.0/(ni*nj)
+     
+! fill into data struct
+  ALLOCATE(obs_data(nobs))
+  n = 0
+  do j = 1, nj
+     do i = 1, ni
+        if (quality_level(i,j) >= min_quality_level) then
+           n = n + 1
+           obs_data(n)%typ      = id_sst_obs
+           obs_data(n)%x_grd(1) = alon2d(i,j)
+           obs_data(n)%x_grd(2) = alat2d(i,j)
+           obs_data(n)%hour     = sst_dtime(i,j)/3600.0
+           obs_data(n)%value    = sea_surface_temperature(i,j)
+           obs_data(n)%oerr     = stde(i,j)
+           obs_data(n)%qkey     = quality_level(i,j)
+        end if
+     end do
+  end do
+  CALL inspect_obs_data(obs_data)
+  if (n/=nobs) then
+     WRITE(6,*) "[err] read_abi_acspo_nc::n/=nobs: n, nobs=", n, nobs
+     STOP (26)
+  end if
+
+END SUBROUTINE read_abi_acspo_nc
+
+SUBROUTINE inspect_obs_data(obs_data)
+  IMPLICIT NONE
+  TYPE(abi_acspo_data),INTENT(IN) :: obs_data(:)
+
+  WRITE(6,*) "[msg] read_abi_acspo_nc::info"
+  WRITE(6,*) "                nobs=", size(obs_data)
+  WRITE(6,*) "  x_grd(1): min, max=", minval(obs_data(:)%x_grd(1)), maxval(obs_data(:)%x_grd(1))
+  WRITE(6,*) "  x_grd(2): min, max=", minval(obs_data(:)%x_grd(2)), maxval(obs_data(:)%x_grd(2))
+  WRITE(6,*) "      hour: min, max=", minval(obs_data(:)%hour), maxval(obs_data(:)%hour)
+  WRITE(6,*) "     value: min, max=", minval(obs_data(:)%value), maxval(obs_data(:)%value)
+  WRITE(6,*) "      oerr: min, max=", minval(obs_data(:)%oerr), maxval(obs_data(:)%oerr)
+  WRITE(6,*) "      qkey: min, max=", minval(obs_data(:)%qkey), maxval(obs_data(:)%qkey)
+
+END SUBROUTINE
+
+END MODULE read_abi_acspo

--- a/src/obs/read_geostationary.f90
+++ b/src/obs/read_geostationary.f90
@@ -1,15 +1,15 @@
-MODULE read_abi_acspo
-  USE common,       ONLY: r_sngl, r_dble, r_size
+MODULE read_geostationary
+  USE common,       ONLY: r_sngl, r_dble, r_size, slen
   USE params_obs,   ONLY: id_sst_obs
   IMPLICIT NONE
 
   PRIVATE
 
-  PUBLIC :: abi_acspo_data
-  PUBLIC :: read_abi_acspo_nc
+  PUBLIC :: sst_geostationary_data
+  PUBLIC :: read_geostationary_nc
   PRIVATE :: inspect_obs_data
 
-  TYPE abi_acspo_data
+  TYPE sst_geostationary_data
     REAL(r_size) :: x_grd(2)  ! longitude, latitude
     REAL(r_size) :: value     ! actual physical value of the parameter measured at this grid point
     REAL(r_size) :: oerr      ! observation standard error
@@ -17,23 +17,24 @@ MODULE read_abi_acspo
     INTEGER :: qkey           ! Quality key
     INTEGER :: typ            ! type of observation (elem)
     LOGICAL :: kept           ! tells letkf whether this obs is kept for assimilation
-  END TYPE abi_acspo_data
+  END TYPE sst_geostationary_data
 
 CONTAINS
 
-SUBROUTINE read_abi_acspo_nc(obsinfile, navinfile, min_quality_level, obs_data, nobs)
+SUBROUTINE read_geostationary_nc(obsinfile, navinfile, min_quality_level, obs_data, nobs)
   USE m_ncio,     ONLY: nc_get_fid, nc_close_fid, nc_rddim, nc_rdvar2d, nc_rdvar1d, &
-                        nc_rdatt
+                        nc_rdatt, nc_fndvar
   IMPLICIT NONE
 
   CHARACTER(*),INTENT(IN) :: obsinfile               
   CHARACTER(*),INTENT(IN) :: navinfile
   INTEGER,     INTENT(IN) :: min_quality_level
-  TYPE(abi_acspo_data),ALLOCATABLE,INTENT(INOUT) :: obs_data(:)
+  TYPE(sst_geostationary_data),ALLOCATABLE,INTENT(INOUT) :: obs_data(:)
   INTEGER,     INTENT(OUT) :: nobs
 
   INTEGER :: fid, ni, nj, i, j, n, qlev
 
+  CHARACTER(slen) :: geoinfile
   REAL(r_size),ALLOCATABLE :: alon2d(:,:), alat2d(:,:)
   REAL(r_size),ALLOCATABLE :: sea_surface_temperature(:,:), stde(:,:), sst_dtime(:,:)
   INTEGER(4),  ALLOCATABLE :: quality_level(:,:)
@@ -48,9 +49,21 @@ SUBROUTINE read_abi_acspo_nc(obsinfile, navinfile, min_quality_level, obs_data, 
   INTEGER :: time(1)
 
 !-------------------------------------------------------------------------------
-! Read dimension & geo info from navigation file (navinfile)
+! Read dimension & geo info:
+! First try if can get lat & lon info from obsinfile. [for GOES13-15/MSG]
+! If not, then read them from navigation file (navinfile) [for ABI/AHI]
 !-------------------------------------------------------------------------------
-  CALL nc_get_fid(trim(navinfile),fid)
+  CALL nc_get_fid(trim(obsinfile),fid)
+  if ( nc_fndvar(fid,"lat") ) then
+     geoinfile = obsinfile
+     WRITE(6,*) "[msg] read_geostationary_nc::read geo from obsinfile=",trim(geoinfile)
+  else
+     geoinfile = navinfile
+     WRITE(6,*) "[msg] read_geostationary_nc::read geo from navinfile=",trim(geoinfile)
+  end if
+  CALL nc_close_fid(fid)
+
+  CALL nc_get_fid(trim(geoinfile),fid)
   CALL nc_rddim(fid,"ni", ni)
   print *, "**************************"
   print *, "ni dimension is = ", ni
@@ -64,23 +77,24 @@ SUBROUTINE read_abi_acspo_nc(obsinfile, navinfile, min_quality_level, obs_data, 
   ALLOCATE(alon2d(ni,nj),alat2d(ni,nj))
   ALLOCATE(valid(ni,nj))
   valid = .TRUE.
+
   CALL nc_rdvar2d(fid,"lon",alon2d)
-  WRITE(6,*) "[msg] read_abi_acspo_nc::alon2d: min, max=", &
+  WRITE(6,*) "[msg] read_geostationary_nc::alon2d: min, max=", &
              minval(alon2d),maxval(alon2d)
   CALL nc_rdvar2d(fid,"lat",alat2d)
-  WRITE(6,*) "[msg] read_abi_acspo_nc::alat2d: min, max=", &
+  WRITE(6,*) "[msg] read_geostationary_nc::alat2d: min, max=", &
              minval(alat2d),maxval(alat2d)
   CALL nc_close_fid(fid)
 
 !-------------------------------------------------------------------------------
-! Read retrieved SST and other info from obs file (obsinfile)
+! Read the observed SST data from obs file (obsinfile)
 !-------------------------------------------------------------------------------
   CALL nc_get_fid(trim(obsinfile),fid)
 
   ALLOCATE(i1buf2d(ni,nj))
   ALLOCATE(i2buf2d(ni,nj))
 
-! SST
+
   CALL nc_rdvar2d(fid, "sea_surface_temperature", i2buf2d)
   CALL nc_rdatt(fid, "sea_surface_temperature","scale_factor", scale_factor)
   CALL nc_rdatt(fid, "sea_surface_temperature","add_offset", offset)
@@ -92,7 +106,7 @@ SUBROUTINE read_abi_acspo_nc(obsinfile, navinfile, min_quality_level, obs_data, 
   end where
   ALLOCATE(sea_surface_temperature(ni,nj))
   sea_surface_temperature = REAL(i2buf2d,r_size)*scale_factor + offset
-  WRITE(6,*) "[msg] read_abi_acspo_nc::sst: min, max=", &
+  WRITE(6,*) "[msg] read_geostationary_nc::sst: min, max=", &
              minval(sea_surface_temperature), maxval(sea_surface_temperature), &
              minval(sea_surface_temperature, mask=valid),&
              maxval(sea_surface_temperature, mask=valid)
@@ -109,17 +123,19 @@ SUBROUTINE read_abi_acspo_nc(obsinfile, navinfile, min_quality_level, obs_data, 
   end where
   ALLOCATE(stde(ni,nj))
   stde = REAL(i1buf2d,r_size)*scale_factor + offset
-  WRITE(6,*) "[msg] read_abi_acspo_nc::stde: min, max=", &
+  WRITE(6,*) "[msg] read_geostationary_nc::stde: min, max=", &
              minval(stde), maxval(stde), &
              minval(stde, mask=valid),maxval(stde, mask=valid)
 
-! sst_time
+!-------------------------------------------------------------------------------
+! Read the base time and time offset
+!-------------------------------------------------------------------------------
   CALL nc_rdvar1d(fid, "time", time)
-  WRITE(6,*) "[msg] read_abi_acspo_nc::time=",time(1)
+  WRITE(6,*) "[msg] read_geostationary_nc::time=",time(1)
   sdate = [1981, 1, 1, 0, 0, 0, 0, 0] ! YYYY/MON/DAY/TZONE/HR/MIN/SEC/MSEC
   tdelta = [0.0,0.0,0.0,REAL(time(1)),0.0] ! DAY/HR/MIN/SEC/MSEC
   CALL w3movdat(tdelta, sdate, obsdate)
-  WRITE(6,*) "[msg] read_abi_acspo_nc::obstime=", obsdate(1:3),obsdate(5:7)
+  WRITE(6,*) "[msg] read_geostationary_nc::obstime=", obsdate(1:3),obsdate(5:7)
 
 ! sst_dtime
   CALL nc_rdvar2d(fid, "sst_dtime", i2buf2d)
@@ -133,11 +149,17 @@ SUBROUTINE read_abi_acspo_nc(obsinfile, navinfile, min_quality_level, obs_data, 
   end where
   ALLOCATE(sst_dtime(ni,nj))
   sst_dtime = REAL(i2buf2d,r_size)*scale_factor + offset
-  WRITE(6,*) "[msg] read_abi_acspo_nc::sst_dtime: min, max=", &
+  WRITE(6,*) "[msg] read_geostationary_nc::sst_dtime: min, max=", &
              minval(sst_dtime), maxval(sst_dtime), &
              minval(sst_dtime, mask=valid),maxval(sst_dtime, mask=valid)
 
-! Quality key (5-best, 4, 3, 2, 1, 0-worst)
+!-------------------------------------------------------------------------------
+! Read the Quality Key (5 is best quality; 0 missing data)
+! 5    == best_quality
+! 4-2  == not used
+! 1    == bad data
+! 0    == missing data
+!-------------------------------------------------------------------------------
   ALLOCATE(quality_level(ni,nj))
   CALL nc_rdvar2d(fid, "quality_level", quality_level)
   CALL nc_rdatt(fid, "quality_level", "_FillValue", FillValue)
@@ -155,16 +177,18 @@ SUBROUTINE read_abi_acspo_nc(obsinfile, navinfile, min_quality_level, obs_data, 
             i1buf2d = 1
         end where
         n = sum(int(i1buf2d,4))
-        WRITE(6,*) "[msg] read_abi_acspo_nc::quality_level, # of obs, %=", i, n, n*100.0/(ni*nj)
+        WRITE(6,*) "[msg] read_geostationary_nc::quality_level, # of obs, %=", i, n, n*100.0/(ni*nj)
      end do
   end if
   where (quality_level == FillValue)
       valid = .FALSE.
   end where
-  !WRITE(6,*) "[msg] read_abi_acspo_nc::quality_level: min, max=", &
+  !WRITE(6,*) "[msg] read_geostationary_nc::quality_level: min, max=", &
   !           minval(quality_level, mask=valid), maxval(quality_level, mask=valid)
-  
-! Close file
+ 
+!-------------------------------------------------------------------------------
+! Close the netcdf file
+!-------------------------------------------------------------------------------
   CALL nc_close_fid(fid)
 
 !-------------------------------------------------------------------------------
@@ -173,14 +197,14 @@ SUBROUTINE read_abi_acspo_nc(obsinfile, navinfile, min_quality_level, obs_data, 
   WRITE(6,*) "Finished reading netCDF file, formatting data..."
 
 ! determine num of valid obs
-  WRITE(6,*) "[msg] read_abi_acspo_nc::use obs with min_quality_level=", min_quality_level
+  WRITE(6,*) "[msg] read_geostationary_nc::use obs with min_quality_level=", min_quality_level
   nobs = 0
   do j = 1, nj; do i = 1, ni
     if (quality_level(i,j) >= min_quality_level.and.valid(i,j)) then
        nobs = nobs + 1
     end if
   end do; end do
-  WRITE(6,*) "[msg] read_abi_acspo_nc::nobs_retained, %=", nobs, nobs*100.0/(ni*nj)
+  WRITE(6,*) "[msg] read_geostationary_nc::nobs_retained, %=", nobs, nobs*100.0/(ni*nj)
      
 ! fill into data struct
   ALLOCATE(obs_data(nobs))
@@ -201,17 +225,17 @@ SUBROUTINE read_abi_acspo_nc(obsinfile, navinfile, min_quality_level, obs_data, 
   end do
   CALL inspect_obs_data(obs_data)
   if (n/=nobs) then
-     WRITE(6,*) "[err] read_abi_acspo_nc::n/=nobs: n, nobs=", n, nobs
+     WRITE(6,*) "[err] read_geostationary_nc::n/=nobs: n, nobs=", n, nobs
      STOP (26)
   end if
 
-END SUBROUTINE read_abi_acspo_nc
+END SUBROUTINE read_geostationary_nc
 
 SUBROUTINE inspect_obs_data(obs_data)
   IMPLICIT NONE
-  TYPE(abi_acspo_data),INTENT(IN) :: obs_data(:)
+  TYPE(sst_geostationary_data),INTENT(IN) :: obs_data(:)
 
-  WRITE(6,*) "[msg] read_abi_acspo_nc::info"
+  WRITE(6,*) "[msg] read_geostationary_nc::info"
   WRITE(6,*) "                nobs=", size(obs_data)
   WRITE(6,*) "  x_grd(1): min, max=", minval(obs_data(:)%x_grd(1)), maxval(obs_data(:)%x_grd(1))
   WRITE(6,*) "  x_grd(2): min, max=", minval(obs_data(:)%x_grd(2)), maxval(obs_data(:)%x_grd(2))
@@ -222,4 +246,4 @@ SUBROUTINE inspect_obs_data(obs_data)
 
 END SUBROUTINE
 
-END MODULE read_abi_acspo
+END MODULE read_geostationary

--- a/src/obs/w3movdat_full.f
+++ b/src/obs/w3movdat_full.f
@@ -1,0 +1,348 @@
+!-----------------------------------------------------------------------
+      subroutine w3movdat(rinc,idat,jdat)
+!$$$   SUBPROGRAM  DOCUMENTATION  BLOCK
+!
+! SUBPROGRAM: W3MOVDAT       RETURN A DATE FROM A TIME INTERVAL AND DATE
+!   AUTHOR: MARK IREDELL     ORG: WP23       DATE: 98-01-05
+!
+! ABSTRACT: THIS SUBPROGRAM RETURNS THE DATE AND TIME THAT IS A GIVEN
+!   NCEP RELATIVE TIME INTERVAL FROM AN NCEP ABSOLUTE DATE AND TIME.
+!   THE OUTPUT IS IN THE NCEP ABSOLUTE DATE AND TIME DATA STRUCTURE.
+!
+! PROGRAM HISTORY LOG:
+!   98-01-05  MARK IREDELL
+!
+! USAGE:  CALL W3MOVDAT(RINC,IDAT,JDAT)
+!
+!   INPUT VARIABLES:
+!     RINC       REAL (5) NCEP RELATIVE TIME INTERVAL
+!                (DAYS, HOURS, MINUTES, SECONDS, MILLISECONDS)
+!     IDAT       INTEGER (8) NCEP ABSOLUTE DATE AND TIME
+!                (YEAR, MONTH, DAY, TIME ZONE,
+!                 HOUR, MINUTE, SECOND, MILLISECOND)
+!
+!   OUTPUT VARIABLES:
+!     JDAT       INTEGER (8) NCEP ABSOLUTE DATE AND TIME
+!                (YEAR, MONTH, DAY, TIME ZONE,
+!                 HOUR, MINUTE, SECOND, MILLISECOND)
+!                (JDAT IS LATER THAN IDAT IF TIME INTERVAL IS POSITIVE.)
+!
+! SUBPROGRAMS CALLED:
+!     IW3JDN         COMPUTE JULIAN DAY NUMBER     
+!     W3FS26         YEAR, MONTH, DAY FROM JULIAN DAY NUMBER
+!     W3REDDAT       REDUCE A TIME INTERVAL TO A CANONICAL FORM
+!
+! ATTRIBUTES:
+!   LANGUAGE: FORTRAN 90
+!
+!$$$
+      real rinc(5)
+      integer idat(8),jdat(8)
+      real rinc1(5),rinc2(5)
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  add the interval to the input time of day and put into reduced form
+!  and then compute new date using julian day arithmetic.
+      rinc1(1)=rinc(1)
+      rinc1(2:5)=rinc(2:5)+idat(5:8)
+      call w3reddat(-1,rinc1,rinc2)
+      jldayn=iw3jdn(idat(1),idat(2),idat(3))+nint(rinc2(1))
+      call w3fs26(jldayn,jdat(1),jdat(2),jdat(3),jdow,jdoy)
+      jdat(4)=idat(4)
+      jdat(5:8)=nint(rinc2(2:5))
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      endsubroutine
+
+
+       FUNCTION IW3JDN(IYEAR,MONTH,IDAY)
+C$$$   SUBPROGRAM  DOCUMENTATION  BLOCK
+C
+C SUBPROGRAM: IW3JDN         COMPUTE JULIAN DAY NUMBER
+C   AUTHOR: JONES,R.E.       ORG: W342       DATE: 87-03-29
+C
+C ABSTRACT: COMPUTES JULIAN DAY NUMBER FROM YEAR (4 DIGITS), MONTH,
+C   AND DAY. IW3JDN IS VALID FOR YEARS 1583 A.D. TO 3300 A.D.
+C   JULIAN DAY NUMBER CAN BE USED TO COMPUTE DAY OF WEEK, DAY OF
+C   YEAR, RECORD NUMBERS IN AN ARCHIVE, REPLACE DAY OF CENTURY,
+C   FIND THE NUMBER OF DAYS BETWEEN TWO DATES.
+C
+C PROGRAM HISTORY LOG:
+C   87-03-29  R.E.JONES
+C   89-10-25  R.E.JONES   CONVERT TO CRAY CFT77 FORTRAN
+C
+C USAGE:   II = IW3JDN(IYEAR,MONTH,IDAY)
+C
+C   INPUT VARIABLES:
+C     NAMES  INTERFACE DESCRIPTION OF VARIABLES AND TYPES
+C     ------ --------- -----------------------------------------------
+C     IYEAR  ARG LIST  INTEGER   YEAR           ( 4 DIGITS)
+C     MONTH  ARG LIST  INTEGER   MONTH OF YEAR   (1 - 12)
+C     IDAY   ARG LIST  INTEGER   DAY OF MONTH    (1 - 31)
+C
+C   OUTPUT VARIABLES:
+C     NAMES  INTERFACE DESCRIPTION OF VARIABLES AND TYPES
+C     ------ --------- -----------------------------------------------
+C     IW3JDN FUNTION   INTEGER   JULIAN DAY NUMBER
+C                      JAN. 1,1960 IS JULIAN DAY NUMBER 2436935
+C                      JAN. 1,1987 IS JULIAN DAY NUMBER 2446797
+C
+C   REMARKS: JULIAN PERIOD WAS DEVISED BY JOSEPH SCALIGER IN 1582.
+C     JULIAN DAY NUMBER #1 STARTED ON JAN. 1,4713 B.C. THREE MAJOR
+C     CHRONOLOGICAL CYCLES BEGIN ON THE SAME DAY. A 28-YEAR SOLAR
+C     CYCLE, A 19-YEAR LUNER CYCLE, A 15-YEAR INDICTION CYCLE, USED
+C     IN ANCIENT ROME TO REGULATE TAXES. IT WILL TAKE 7980 YEARS
+C     TO COMPLETE THE PERIOD, THE PRODUCT OF 28, 19, AND 15.
+C     SCALIGER NAMED THE PERIOD, DATE, AND NUMBER AFTER HIS FATHER
+C     JULIUS (NOT AFTER THE JULIAN CALENDAR). THIS SEEMS TO HAVE
+C     CAUSED A LOT OF CONFUSION IN TEXT BOOKS. SCALIGER NAME IS
+C     SPELLED THREE DIFFERENT WAYS. JULIAN DATE AND JULIAN DAY
+C     NUMBER ARE INTERCHANGED. A JULIAN DATE IS USED BY ASTRONOMERS
+C     TO COMPUTE ACCURATE TIME, IT HAS A FRACTION. WHEN TRUNCATED TO
+C     AN INTEGER IT IS CALLED AN JULIAN DAY NUMBER. THIS FUNCTION
+C     WAS IN A LETTER TO THE EDITOR OF THE COMMUNICATIONS OF THE ACM
+C     VOLUME 11 / NUMBER 10 / OCTOBER 1968. THE JULIAN DAY NUMBER
+C     CAN BE CONVERTED TO A YEAR, MONTH, DAY, DAY OF WEEK, DAY OF
+C     YEAR BY CALLING SUBROUTINE W3FS26.
+C
+C ATTRIBUTES:
+C   LANGUAGE: CRAY CFT77 FORTRAN
+C   MACHINE:  CRAY Y-MP8/864, CRAY Y-MP EL2/256
+C
+C$$$
+C
+       IW3JDN  =    IDAY - 32075
+     &            + 1461 * (IYEAR + 4800 + (MONTH - 14) / 12) / 4
+     &            + 367 * (MONTH - 2 - (MONTH -14) / 12 * 12) / 12
+     &            - 3 * ((IYEAR + 4900 + (MONTH - 14) / 12) / 100) / 4
+       RETURN
+       ENDFUNCTION
+
+
+      subroutine w3reddat(it,rinc,dinc)
+!$$$   SUBPROGRAM  DOCUMENTATION  BLOCK
+!
+! SUBPROGRAM: W3REDDAT       REDUCE A TIME INTERVAL TO A CANONICAL FORM
+!   AUTHOR: MARK IREDELL     ORG: WP23       DATE: 98-01-05
+!
+! ABSTRACT: THIS SUBPROGRAM REDUCES AN NCEP RELATIVE TIME INTERVAL
+!   INTO ONE OF SEVEN CANONICAL FORMS, DEPENDING ON THE INPUT IT VALUE.
+!
+!   First reduced format type (IT=-1):
+!        RINC(1) is an arbitrary integer.
+!        RINC(2) is an integer between 00 and 23, inclusive.
+!        RINC(3) is an integer between 00 and 59, inclusive.
+!        RINC(4) is an integer between 00 and 59, inclusive.
+!        RINC(5) is an integer between 000 and 999, inclusive.
+!      If RINC(1) is negative, then the time interval is negative.
+!    
+!   Second reduced format type (IT=0):
+!      If the time interval is not negative, then the format is:
+!        RINC(1) is zero or a positive integer. 
+!        RINC(2) is an integer between 00 and 23, inclusive.
+!        RINC(3) is an integer between 00 and 59, inclusive.
+!        RINC(4) is an integer between 00 and 59, inclusive.
+!        RINC(5) is an integer between 000 and 999, inclusive.
+!      Otherwise if the time interval is negative, then the format is:
+!        RINC(1) is zero or a negative integer. 
+!        RINC(2) is an integer between 00 and -23, inclusive.
+!        RINC(3) is an integer between 00 and -59, inclusive.
+!        RINC(4) is an integer between 00 and -59, inclusive.
+!        RINC(5) is an integer between 000 and -999, inclusive.
+!    
+!   Days format type (IT=1):
+!        RINC(1) is arbitrary.
+!        RINC(2) is zero.
+!        RINC(3) is zero.
+!        RINC(4) is zero.
+!        RINC(5) is zero.
+!    
+!   Hours format type (IT=2):
+!        RINC(1) is zero.
+!        RINC(2) is arbitrary.
+!        RINC(3) is zero.
+!        RINC(4) is zero.
+!        RINC(5) is zero.
+!      (This format should not express time intervals longer than 300 years.)
+!    
+!   Minutes format type (IT=3):
+!        RINC(1) is zero.
+!        RINC(2) is zero.
+!        RINC(3) is arbitrary.
+!        RINC(4) is zero.
+!        RINC(5) is zero.
+!      (This format should not express time intervals longer than five years.)
+!    
+!   Seconds format type (IT=4):
+!        RINC(1) is zero.
+!        RINC(2) is zero.
+!        RINC(3) is zero.
+!        RINC(4) is arbitrary.
+!        RINC(5) is zero.
+!      (This format should not express time intervals longer than one month.)
+!    
+!   Milliseconds format type (IT=5):
+!        RINC(1) is zero.
+!        RINC(2) is zero.
+!        RINC(3) is zero.
+!        RINC(4) is zero.
+!        RINC(5) is arbitrary.
+!     (This format should not express time intervals longer than one hour.)
+!
+! PROGRAM HISTORY LOG:
+!   98-01-05  MARK IREDELL
+!
+! USAGE:  CALL W3REDDAT(IT,RINC,DINC)
+!
+!   INPUT VARIABLES:
+!     IT         INTEGER RELATIVE TIME INTERVAL FORMAT TYPE
+!                (-1 FOR FIRST REDUCED TYPE (HOURS ALWAYS POSITIVE),
+!                 0 FOR SECOND REDUCED TYPE (HOURS CAN BE NEGATIVE),
+!                 1 FOR DAYS ONLY, 2 FOR HOURS ONLY, 3 FOR MINUTES ONLY,
+!                 4 FOR SECONDS ONLY, 5 FOR MILLISECONDS ONLY)
+!     RINC       REAL (5) NCEP RELATIVE TIME INTERVAL
+!                (DAYS, HOURS, MINUTES, SECONDS, MILLISECONDS)
+!
+!   OUTPUT VARIABLES:
+!     DINC       REAL (5) NCEP RELATIVE TIME INTERVAL
+!                (DAYS, HOURS, MINUTES, SECONDS, MILLISECONDS)
+!
+! SUBPROGRAMS CALLED:
+!
+! ATTRIBUTES:
+!   LANGUAGE: FORTRAN 90
+!
+!$$$
+      real rinc(5),dinc(5)
+!  parameters for number of units in a day
+!  and number of milliseconds in a unit
+!  and number of next smaller units in a unit, respectively
+      integer,dimension(5),parameter:: itd=(/1,24,1440,86400,86400000/),
+     &                                 itm=itd(5)/itd
+      integer,dimension(4),parameter:: itn=itd(2:5)/itd(1:4)
+      integer,parameter:: np=16
+      integer iinc(4),jinc(5),kinc(5)
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  first reduce to the first reduced form
+      iinc=floor(rinc(1:4))
+!  convert all positive fractional parts to milliseconds
+!  and determine canonical milliseconds
+      jinc(5)=nint(dot_product(rinc(1:4)-iinc,real(itm(1:4)))+rinc(5))
+      kinc(5)=modulo(jinc(5),itn(4))
+!  convert remainder to seconds and determine canonical seconds
+      jinc(4)=iinc(4)+(jinc(5)-kinc(5))/itn(4)
+      kinc(4)=modulo(jinc(4),itn(3))
+!  convert remainder to minutes and determine canonical minutes
+      jinc(3)=iinc(3)+(jinc(4)-kinc(4))/itn(3)
+      kinc(3)=modulo(jinc(3),itn(2))
+!  convert remainder to hours and determine canonical hours
+      jinc(2)=iinc(2)+(jinc(3)-kinc(3))/itn(2)
+      kinc(2)=modulo(jinc(2),itn(1))
+!  convert remainder to days and compute milliseconds of the day
+      kinc(1)=iinc(1)+(jinc(2)-kinc(2))/itn(1)
+      ms=dot_product(kinc(2:5),itm(2:5))
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  next reduce to either single value canonical form
+!  or to one of the two reduced forms
+      if(it.ge.1.and.it.le.5) then
+!  ensure that exact multiples of 1./np are expressed exactly
+!  (other fractions may have precision errors)
+        rp=(np*ms)/itm(it)+mod(np*ms,itm(it))/real(itm(it))
+        dinc=0
+        dinc(it)=real(kinc(1))*itd(it)+rp/np
+      else
+!  the reduced form is done except the second reduced form is modified
+!  for negative time intervals with fractional days
+        dinc=kinc
+        if(it.eq.0.and.kinc(1).lt.0.and.ms.gt.0) then
+          dinc(1)=dinc(1)+1
+          dinc(2:5)=mod(ms-itm(1),itm(1:4))/itm(2:5)
+        endif
+      endif
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      endsubroutine
+       SUBROUTINE W3FS26(JLDAYN,IYEAR,MONTH,IDAY,IDAYWK,IDAYYR)
+C$$$   SUBPROGRAM  DOCUMENTATION  BLOCK
+C
+C SUBPROGRAM: W3FS26         YEAR, MONTH, DAY FROM JULIAN DAY NUMBER
+C   AUTHOR: JONES,R.E.       ORG: W342       DATE: 87-03-29
+C
+C ABSTRACT: COMPUTES YEAR (4 DIGITS), MONTH, DAY, DAY OF WEEK, DAY
+C   OF YEAR FROM JULIAN DAY NUMBER. THIS SUBROUTINE WILL WORK
+C   FROM 1583 A.D. TO 3300 A.D.
+C
+C PROGRAM HISTORY LOG:
+C   87-03-29  R.E.JONES
+C   89-10-25  R.E.JONES   CONVERT TO CRAY CFT77 FORTRAN
+C
+C USAGE:  CALL W3FS26(JLDAYN,IYEAR,MONTH,IDAY,IDAYWK,IDAYYR)
+C
+C   INPUT VARIABLES:
+C     NAMES  INTERFACE DESCRIPTION OF VARIABLES AND TYPES
+C     ------ --------- -----------------------------------------------
+C     JLDAYN ARG LIST  INTEGER   JULIAN DAY NUMBER
+C
+C   OUTPUT VARIABLES:
+C     NAMES  INTERFACE DESCRIPTION OF VARIABLES AND TYPES
+C     ------ --------- -----------------------------------------------
+C     IYEAR  ARG LIST  INTEGER   YEAR  (4 DIGITS)
+C     MONTH  ARG LIST  INTEGER   MONTH
+C     IDAY   ARG LIST  INTEGER   DAY
+C     IDAYWK ARG LIST  INTEGER   DAY OF WEEK (1 IS SUNDAY, 7 IS SAT)
+C     IDAYYR ARG LIST  INTEGER   DAY OF YEAR (1 TO 366)
+C
+C   REMARKS: A JULIAN DAY NUMBER CAN BE COMPUTED BY USING ONE OF THE
+C     FOLLOWING STATEMENT FUNCTIONS. A DAY OF WEEK CAN BE COMPUTED
+C     FROM THE JULIAN DAY NUMBER. A DAY OF YEAR CAN BE COMPUTED FROM
+C     A JULIAN DAY NUMBER AND YEAR.
+C
+C      IYEAR (4 DIGITS)
+C
+C      JDN(IYEAR,MONTH,IDAY) = IDAY - 32075
+C    &            + 1461 * (IYEAR + 4800 + (MONTH - 14) / 12) / 4
+C    &            + 367 * (MONTH - 2 - (MONTH -14) / 12 * 12) / 12
+C    &            - 3 * ((IYEAR + 4900 + (MONTH - 14) / 12) / 100) / 4
+C
+C      IYR (4 DIGITS) , IDYR(1-366) DAY OF YEAR
+C
+C      JULIAN(IYR,IDYR) = -31739 + 1461 * (IYR + 4799) / 4
+C    &                    -3 * ((IYR + 4899) / 100) / 4 + IDYR
+C
+C      DAY OF WEEK FROM JULIAN DAY NUMBER, 1 IS SUNDAY, 7 IS SATURDAY.
+C
+C      JDAYWK(JLDAYN) = MOD((JLDAYN + 1),7) + 1
+C
+C      DAY OF YEAR FROM JULIAN DAY NUMBER AND 4 DIGIT YEAR.
+C
+C      JDAYYR(JLDAYN,IYEAR) = JLDAYN -
+C     &  (-31739+1461*(IYEAR+4799)/4-3*((IYEAR+4899)/100)/4)
+C
+C      THE FIRST FUNCTION WAS IN A LETTER TO THE EDITOR COMMUNICATIONS
+C      OF THE ACM  VOLUME 11 / NUMBER 10 / OCTOBER, 1968. THE 2ND
+C      FUNCTION WAS DERIVED FROM THE FIRST. THIS SUBROUTINE WAS ALSO
+C      INCLUDED IN THE SAME LETTER. JULIAN DAY NUMBER 1 IS
+C      JAN 1,4713 B.C. A JULIAN DAY NUMBER CAN BE USED TO REPLACE A
+C      DAY OF CENTURY, THIS WILL TAKE CARE OF THE DATE PROBLEM IN
+C      THE YEAR 2000, OR REDUCE PROGRAM CHANGES TO ONE LINE CHANGE
+C      OF 1900 TO 2000. JULIAN DAY NUMBERS CAN BE USED FOR FINDING
+C      RECORD NUMBERS IN AN ARCHIVE OR DAY OF WEEK, OR DAY OF YEAR.
+C
+C ATTRIBUTES:
+C   LANGUAGE: CRAY CFT77 FORTRAN
+C   MACHINE:  CRAY Y-MP8/864
+C
+C$$$
+C
+       L      = JLDAYN + 68569
+       N      = 4 * L / 146097
+       L      = L - (146097 * N + 3) / 4
+       I      = 4000 * (L + 1) / 1461001
+       L      = L - 1461 * I / 4 + 31
+       J      = 80 * L / 2447
+       IDAY   = L - 2447 * J / 80
+       L      = J / 11
+       MONTH  = J + 2 - 12 * L
+       IYEAR  = 100 * (N - 49) + I + L
+       IDAYWK = MOD((JLDAYN + 1),7) + 1
+       IDAYYR = JLDAYN -
+     &  (-31739 +1461 * (IYEAR+4799) / 4 - 3 * ((IYEAR+4899)/100)/4)
+       RETURN
+       END

--- a/support/io/README.md
+++ b/support/io/README.md
@@ -1,0 +1,1 @@
+F90GIO (https://github.com/cd10kfsu/F90GIO) developed by Cheng Da (cda@umd.edu)

--- a/support/io/m_ncio.f90
+++ b/support/io/m_ncio.f90
@@ -1,0 +1,408 @@
+MODULE m_ncio
+!=====================================================================
+! Purpose:
+!   Module for simple NetCDF I/O. 
+!   Modified from cheng's F90GIO (https://github.com/cd10kfsu/F90GIO):
+!   1. Use file id to read all things, to reduce the frequency of opening/closing files
+!   2. Remove size & shape checks
+  USE NetCDF, ONLY: NF90_NOWRITE, NF90_WRITE, NF90_NOERR, NF90_CLOBBER, &
+                    NF90_DOUBLE, NF90_FLOAT, NF90_INT, NF90_SHORT, NF90_BYTE, &
+                    NF90_UNLIMITED, &
+                    NF90_Open, NF90_Close, &
+                    NF90_inquire, NF90_Inq_Varid, NF90_Inquire_Variable, &
+                    NF90_Inq_DimID, NF90_Inquire_Dimension, &
+                    NF90_Get_Var, NF90_Put_Var, &
+                    NF90_Create, NF90_Def_dim, NF90_Def_Var, NF90_Enddef, NF90_reDef, &
+                    NF90_GLOBAL, NF90_Get_Att
+  IMPLICIT NONE
+  PRIVATE
+  
+!  PUBLIC :: NF90_DOUBLE, NF90_FLOAT, NF90_INT, NF90_SHORT, NF90_BYTE
+
+! open/close file
+  PUBLIC :: nc_get_fid, nc_close_fid
+
+! Read Attributes
+  PUBLIC :: nc_rdatt
+
+! low-level read Attributes
+  PUBLIC :: nc_rdatt_str, nc_rdatt_i1, nc_rdatt_i2, nc_rdatt_i4, &
+            nc_rdatt_r4, nc_rdatt_r8
+! Get dimension
+  PUBLIC :: nc_rddim
+
+! read ND vars
+  PUBLIC :: nc_rdvar1d, nc_rdvar2d, nc_rdvar3d, nc_rdvar4d
+
+! low-level Read 1D
+  PUBLIC :: nc_rdvar1d_i1, nc_rdvar1d_i2, nc_rdvar1d_i4, nc_rdvar1d_r4, &
+            nc_rdvar1d_r8
+! low-level Read 2D
+  PUBLIC :: nc_rdvar2d_i1, nc_rdvar2d_i2, nc_rdvar2d_i4, nc_rdvar2d_r4, &
+            nc_rdvar2d_r8
+! low-level Read 3D
+  PUBLIC :: nc_rdvar3d_i1, nc_rdvar3d_i2, nc_rdvar3d_i4, nc_rdvar3d_r4, &
+            nc_rdvar3d_r8
+! low-level Read 4D
+  PUBLIC :: nc_rdvar4d_i1, nc_rdvar4d_i2, nc_rdvar4d_i4, nc_rdvar4d_r4, &
+            nc_rdvar4d_r8
+
+!-------------------------------------------------------------------------------
+! Internal vars & subs
+  INTERFACE nc_rdatt
+    MODULE PROCEDURE nc_rdatt_str
+    MODULE PROCEDURE nc_rdatt_i1, nc_rdatt_i2, nc_rdatt_i4
+    MODULE PROCEDURE nc_rdatt_r4, nc_rdatt_r8
+  END INTERFACE
+
+  INTERFACE nc_rdvar1d
+    MODULE PROCEDURE nc_rdvar1d_i1, nc_rdvar1d_i2, nc_rdvar1d_i4
+    MODULE PROCEDURE nc_rdvar1d_r4, nc_rdvar1d_r8
+  END INTERFACE
+
+  INTERFACE nc_rdvar2d
+    MODULE PROCEDURE nc_rdvar2d_i1, nc_rdvar2d_i2, nc_rdvar2d_i4
+    MODULE PROCEDURE nc_rdvar2d_r4, nc_rdvar2d_r8
+  END INTERFACE
+
+  INTERFACE nc_rdvar3d
+    MODULE PROCEDURE nc_rdvar3d_i1, nc_rdvar3d_i2, nc_rdvar3d_i4
+    MODULE PROCEDURE nc_rdvar3d_r4, nc_rdvar3d_r8
+  END INTERFACE
+
+  INTERFACE nc_rdvar4d
+    MODULE PROCEDURE nc_rdvar4d_i1, nc_rdvar4d_i2, nc_rdvar4d_i4
+    MODULE PROCEDURE nc_rdvar4d_r4, nc_rdvar4d_r8
+  END INTERFACE
+
+  INTEGER,PARAMETER :: i1 = 1
+  INTEGER,PARAMETER :: i2 = 2
+  INTEGER,PARAMETER :: i4 = 4
+  INTEGER,PARAMETER :: i8 = 8
+  INTEGER,PARAMETER :: r4 = 4
+  INTEGER,PARAMETER :: r8 = 8
+
+  INTEGER,SAVE,PRIVATE :: lout_log = 6 ! output log
+
+  TYPE::t_errcode
+    ! i2 supports -128 -> 127
+    INTEGER(i1) :: fid    = 1
+    INTEGER(i1) :: varid  = 2
+    INTEGER(i1) :: varval = 3
+    INTEGER(i1) :: attval = 4
+    INTEGER(i1) :: dimid  = 5
+    INTEGER(i1) :: dimval = 6
+    INTEGER(i1) :: undef  = 127 ! max positive for signed 8-byte int
+  END TYPE 
+  TYPE(t_errcode),SAVE,PRIVATE:: errcode
+
+  PRIVATE :: mystop
+
+CONTAINS
+
+
+!--------------------------------------------------------------------------------
+! Utils
+!--------------------------------------------------------------------------------
+SUBROUTINE mystop(errcode)
+  IMPLICIT NONE
+  INTEGER(i1),INTENT(IN) :: errcode
+! change this part to MPI_Abort if using MPI
+  STOP (INT(errcode,i4))
+END SUBROUTINE 
+
+
+!--------------------------------------------------------------------------------
+! open/close nc file
+!--------------------------------------------------------------------------------
+SUBROUTINE nc_get_fid(filename,fid)
+  IMPLICIT NONE
+
+  CHARACTER(*),INTENT(IN)  :: filename
+  INTEGER(i4), INTENT(OUT) :: fid
+  INTEGER(i4) :: istat
+
+  istat = NF90_Open( TRIM(filename), NF90_NOWRITE, fid)
+  if (istat /= NF90_NOERR) then
+     write(lout_log,*) "[err] nc_get_fid::Fail to get fid of file:",trim(filename)
+     call mystop(errcode%fid)
+  end if
+
+END SUBROUTINE nc_get_fid
+
+
+SUBROUTINE nc_close_fid(fid)
+  IMPLICIT NONE
+
+  INTEGER(i4),INTENT(IN) :: fid
+  INTEGER(i4) :: istat
+
+  istat = NF90_Close(fid)
+  if (istat /= NF90_NOERR) then
+     write(lout_log,*) "[err] nc_close_fid::Fail to close file with fid=",fid
+     call mystop(errcode%fid)
+  end if
+
+END SUBROUTINE nc_close_fid
+
+!--------------------------------------------------------------------------------
+! read 1D
+!--------------------------------------------------------------------------------
+SUBROUTINE nc_rdvar1d_i1(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  INTEGER(i1), INTENT(OUT) :: varval(:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdvar1d_i2(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  INTEGER(i2), INTENT(OUT) :: varval(:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdvar1d_i4(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  INTEGER(i4), INTENT(OUT) :: varval(:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdvar1d_r4(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  REAL(r4), INTENT(OUT) :: varval(:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdvar1d_r8(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  REAL(r8), INTENT(OUT) :: varval(:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+
+!--------------------------------------------------------------------------------
+! read 2D
+!--------------------------------------------------------------------------------
+SUBROUTINE nc_rdvar2d_i1(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  INTEGER(i1), INTENT(OUT) :: varval(:,:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdvar2d_i2(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  INTEGER(i2), INTENT(OUT) :: varval(:,:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdvar2d_i4(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  INTEGER(i4), INTENT(OUT) :: varval(:,:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdvar2d_r4(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  REAL(r4), INTENT(OUT) :: varval(:,:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdvar2d_r8(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  REAL(r8), INTENT(OUT) :: varval(:,:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+
+!--------------------------------------------------------------------------------
+! read 3D
+!--------------------------------------------------------------------------------
+SUBROUTINE nc_rdvar3d_i1(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  INTEGER(i1), INTENT(OUT) :: varval(:,:,:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdvar3d_i2(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  INTEGER(i2), INTENT(OUT) :: varval(:,:,:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdvar3d_i4(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  INTEGER(i4), INTENT(OUT) :: varval(:,:,:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdvar3d_r4(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  REAL(r4), INTENT(OUT) :: varval(:,:,:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdvar3d_r8(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  REAL(r8), INTENT(OUT) :: varval(:,:,:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+!--------------------------------------------------------------------------------
+! read 4D
+!--------------------------------------------------------------------------------
+SUBROUTINE nc_rdvar4d_i1(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  INTEGER(i1), INTENT(OUT) :: varval(:,:,:,:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdvar4d_i2(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  INTEGER(i2), INTENT(OUT) :: varval(:,:,:,:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdvar4d_i4(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  INTEGER(i4), INTENT(OUT) :: varval(:,:,:,:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdvar4d_r4(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  REAL(r4), INTENT(OUT) :: varval(:,:,:,:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdvar4d_r8(fid, varname, varval)
+  IMPLICIT NONE
+  INTEGER(i4),INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  REAL(r8), INTENT(OUT) :: varval(:,:,:,:)
+  include "nc_rdvar.f90.inc"
+END SUBROUTINE 
+
+
+!--------------------------------------------------------------------------------
+! read attributes
+!--------------------------------------------------------------------------------
+SUBROUTINE nc_rdatt_str(fid, varname, attname, attval)
+  IMPLICIT NONE
+
+  INTEGER(i4), INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname, attname
+  CHARACTER(*),INTENT(INOUT) :: attval
+  include "nc_rdatt.f90.inc"
+END SUBROUTINE 
+
+
+SUBROUTINE nc_rdatt_i1(fid, varname, attname, attval)
+  IMPLICIT NONE
+
+  INTEGER(i4), INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname, attname
+  INTEGER(i1),    INTENT(OUT) :: attval
+  include "nc_rdatt.f90.inc"
+END SUBROUTINE 
+
+SUBROUTINE nc_rdatt_i2(fid, varname, attname, attval)
+  IMPLICIT NONE
+
+  INTEGER(i4), INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname, attname
+  INTEGER(i2),    INTENT(OUT) :: attval
+  include "nc_rdatt.f90.inc"
+END SUBROUTINE
+
+SUBROUTINE nc_rdatt_i4(fid, varname, attname, attval)
+  IMPLICIT NONE
+
+  INTEGER(i4), INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname, attname
+  INTEGER(i4), INTENT(OUT) :: attval
+  include "nc_rdatt.f90.inc"
+END SUBROUTINE
+
+SUBROUTINE nc_rdatt_r4(fid, varname, attname, attval)
+  IMPLICIT NONE
+
+  INTEGER(i4), INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname, attname
+  REAL(r4),    INTENT(OUT) :: attval
+  include "nc_rdatt.f90.inc"
+END SUBROUTINE
+
+SUBROUTINE nc_rdatt_r8(fid, varname, attname, attval)
+  IMPLICIT NONE
+
+  INTEGER(i4), INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname, attname
+  REAL(r8),    INTENT(OUT) :: attval
+  include "nc_rdatt.f90.inc"
+END SUBROUTINE
+
+
+!--------------------------------------------------------------------------------
+! read dimension
+!--------------------------------------------------------------------------------
+SUBROUTINE nc_rddim(fid, dimname, dimval)
+  IMPLICIT NONE
+
+  INTEGER(i4), INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: dimname
+  INTEGER(i4), INTENT(OUT) :: dimval
+
+  INTEGER(i4) :: istat, dimid
+
+  istat = NF90_INQ_DIMID(fid,trim(dimname),dimid)
+  if (istat /= NF90_NOERR) then
+     write(lout_log,*) "[err] nc_rddim::Fail to get dimid of dim:",trim(dimname)
+     call mystop(errcode%dimid)
+  end if
+  istat = NF90_INQUIRE_DIMENSION(fid,dimid,len=dimval)
+  if (istat /= NF90_NOERR) then
+     write(lout_log,*) "[err] nc_rddim::Fail to get dim val of dim:",trim(dimname)
+     call mystop(errcode%dimval)
+  end if
+
+END SUBROUTINE
+
+
+ENDMODULE m_ncio

--- a/support/io/m_ncio.f90
+++ b/support/io/m_ncio.f90
@@ -31,6 +31,9 @@ MODULE m_ncio
 ! Get dimension
   PUBLIC :: nc_rddim
 
+! Check if var/dim in a file
+  PUBLIC :: nc_fndvar, nc_fnddim
+
 ! read ND vars
   PUBLIC :: nc_rdvar1d, nc_rdvar2d, nc_rdvar3d, nc_rdvar4d
 
@@ -403,6 +406,52 @@ SUBROUTINE nc_rddim(fid, dimname, dimval)
   end if
 
 END SUBROUTINE
+
+!--------------------------------------------------------------------------------
+! find if dim exist in a nc file by file id
+!--------------------------------------------------------------------------------
+FUNCTION nc_fnddim(fid, dimname, dimid) result (found)
+  IMPLICIT NONE
+
+  INTEGER(i4), INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: dimname
+  INTEGER(i4), INTENT(OUT),OPTIONAL :: dimid
+  LOGICAL :: found
+
+  INTEGER(i4) :: istat, dimid_
+
+  istat = NF90_INQ_DIMID(fid,trim(dimname),dimid_)
+  if (istat /= NF90_NOERR) then
+     found = .FALSE.
+  else 
+     found = .TRUE.
+  end if
+  if (PRESENT(dimid)) dimid = dimid_
+
+END FUNCTION
+
+!--------------------------------------------------------------------------------
+! find if var exist in a nc file by file id
+!--------------------------------------------------------------------------------
+FUNCTION nc_fndvar(fid, varname, varid) result (found)
+  IMPLICIT NONE
+
+  INTEGER(i4), INTENT(IN) :: fid
+  CHARACTER(*),INTENT(IN) :: varname
+  INTEGER(i4), INTENT(OUT),OPTIONAL :: varid
+  LOGICAL :: found
+
+  INTEGER(i4) :: istat, varid_
+
+  istat = NF90_INQ_VARID(fid,trim(varname),varid_)
+  if (istat /= NF90_NOERR) then
+     found = .FALSE.
+  else 
+     found = .TRUE.
+  end if
+  if (PRESENT(varid)) varid = varid_
+
+END FUNCTION
 
 
 ENDMODULE m_ncio

--- a/support/io/nc_rdatt.f90.inc
+++ b/support/io/nc_rdatt.f90.inc
@@ -1,0 +1,16 @@
+  INTEGER(i4) :: varid, istat
+
+  if (len_trim(varname).EQ.0) then
+     varid = NF90_GLOBAL
+  else
+     istat = NF90_INQ_VARID(fid, trim(varname), varid)
+     if (istat /= NF90_NOERR) then
+        write(lout_log,*) "[err] nc_rdatt::Fail to get varid of var:",trim(varname)
+        call mystop(errcode%varid)
+     end if
+  end if
+  istat = NF90_GET_ATT(fid, varid, trim(attname), attval)
+  if (istat /= NF90_NOERR) then
+     write(lout_log,*) "[err] nc_rdatt::Fail to get att: varname, attname=", trim(varname), trim(attname)
+     call mystop(errcode%attval)
+  end if

--- a/support/io/nc_rdvar.f90.inc
+++ b/support/io/nc_rdvar.f90.inc
@@ -1,0 +1,13 @@
+  INTEGER(i4) :: istat, varid
+
+  istat = NF90_INQ_VARID(fid, trim(varname), varid)
+  if (istat /= NF90_NOERR) then
+     write(lout_log,*) "[err] rc_rdvar*d::Fail to get varid of var: ",trim(varname)
+     call mystop(errcode%varid)
+  end if
+
+  istat = NF90_GET_VAR(fid, varid, varval)
+  if (istat /= NF90_NOERR) then
+     write(lout_log,*) "[err] rc_rdvar*d::Fail to get value of var: ",trim(varname)
+     call mystop(errcode%varval)
+  end if

--- a/utils/obs_proc/level-2/get_l2p_ghrsst_geostationary.py
+++ b/utils/obs_proc/level-2/get_l2p_ghrsst_geostationary.py
@@ -5,6 +5,9 @@ Example:
 
 PYTHONPATH=../../pycommon ./get_l2p_ghrsst_star.py --start_date 20220110 --end_date 20220111 --sis ABI_G17 --outdir ./ --topdir_name test_l2p_sst --skip_remote_check  --get_nav_file --verbose --log
 
+PYTHONPATH=../../pycommon ./get_l2p_ghrsst_star.py --start_date 20220110 --end_date 20220111 --sis SEVIRI_MSG01 --outdir ./ --topdir_name test_l2p_sst --skip_remote_check  --get_nav_file --verbose --log
+
+PYTHONPATH=../../pycommon ./get_l2p_ghrsst_star.py --start_date 20200110 --end_date 20200111 --sis IMGR_G15 --outdir ./ --topdir_name test_l2p_sst --skip_remote_check  --get_nav_file --verbose --log
 """
 
 import common
@@ -14,9 +17,15 @@ import subprocess as sp
 import os, sys
 
 def get_sis_info(sis):
-    sis_dict={"ABI_G16":{"sat":"GOES16", "ver":"v2.70", "geodir":"docs", "geofile":"G16_075_0_W.nc"}, 
-              "ABI_G17":{"sat":"GOES17", "ver":"v2.71", "geodir":"nav", "geofile":"G17_137_0_W.nc"},
-              "H8":     {}
+    sis_dict={"ABI_G16":     {"sat":"GOES16", "algo":"STAR", "ver":"v2.70", "geodir":"docs", "geofile":"G16_075_0_W.nc"}, 
+              "ABI_G17":     {"sat":"GOES17", "algo":"STAR", "ver":"v2.71", "geodir":"nav",  "geofile":"G17_137_0_W.nc"},
+              "AHI_H08":     {"sat":"H08",    "algo":"STAR", "ver":"v2.70", "geodir":"nav",  "geofile":"H08_140_7_E.nc"},
+              "IMGR_G13":    {"sat":"GOES13", "algo":"OSPO", "ver":"v1",    "geodir":None,   "geofile":None            },
+              "IMGR_G15":    {"sat":"GOES15", "algo":"OSPO", "ver":"v1",    "geodir":None,   "geofile":None            },
+              "SEVIRI_MSG01":{"sat":"MSG01",  "algo":"OSPO", "ver":"v1",    "geodir":None,   "geofile":None            },
+              "SEVIRI_MSG02":{"sat":"MSG02",  "algo":"OSPO", "ver":"v1",    "geodir":None,   "geofile":None            },
+              "SEVIRI_MSG03":{"sat":"MSG03",  "algo":"OSPO", "ver":"v1",    "geodir":None,   "geofile":None            },
+              "SEVIRI_MSG04":{"sat":"MSG04",  "algo":"OSPO", "ver":"v1",    "geodir":None,   "geofile":None            }
     }
     if sis in sis_dict.keys():
         info = sis_dict[sis]
@@ -79,7 +88,7 @@ if proc.returncode != 0:
     logging.critical("{}\n\nSTDOUT: {}\nERR: {}\n".format(errmsg, out.decode(), err.decode()))
     sys.exit(1)
 
-if args.get_nav_file:
+if args.get_nav_file and sis_info['geofile'] is not None:
     navdir = args.outdir + "/" + args.topdir_name + "/" + args.sis + "/nav"
     if args.verbose:
         logging.debug(navdir)
@@ -106,7 +115,7 @@ while cdate <= args.end_date:
 
     if not args.skip_remote_check:
         # check if remote files exist. Raise error if remote files do not exist
-        cmd_inq = 'wget -r -l1 -np -nH --spider --cut-dirs 20 "https://opendap.jpl.nasa.gov/opendap/hyrax/allData/ghrsst/data/GDS2/L2P/{}/STAR/{}/{:04d}/{:03d}/" -A "{:04d}*.nc" -P ./ -e robots=off'.format(sis_info["sat"], sis_info["ver"], cdate.year, julian_day, cdate.year)
+        cmd_inq = 'wget -r -l1 -np -nH --spider --cut-dirs 20 "https://opendap.jpl.nasa.gov/opendap/hyrax/allData/ghrsst/data/GDS2/L2P/{}/{}/{}/{:04d}/{:03d}/" -A "{:04d}*.nc" -P ./ -e robots=off'.format(sis_info["sat"], sis_info['algo'], sis_info["ver"], cdate.year, julian_day, cdate.year)
 
         if args.verbose:
             logging.debug(cmd_inq)
@@ -126,7 +135,7 @@ while cdate <= args.end_date:
         os.makedirs(cdir)
 
     # start daily download
-    cmd_get = 'wget -r -l1 -np -nH --cut-dirs 20 "https://opendap.jpl.nasa.gov/opendap/hyrax/allData/ghrsst/data/GDS2/L2P/{}/STAR/{}/{:04d}/{:03d}/" -A "{:04d}*.nc" -P ./ -e robots=off'.format(sis_info["sat"], sis_info["ver"], cdate.year, julian_day, cdate.year)
+    cmd_get = 'wget -r -l1 -np -nH --cut-dirs 20 "https://opendap.jpl.nasa.gov/opendap/hyrax/allData/ghrsst/data/GDS2/L2P/{}/{}/{}/{:04d}/{:03d}/" -A "{:04d}*.nc" -P ./ -e robots=off'.format(sis_info["sat"], sis_info['algo'], sis_info["ver"], cdate.year, julian_day, cdate.year)
     if args.verbose:
         logging.debug(cmd_get)
     proc = sp.Popen(cmd_get, shell=True, cwd = cdir, stdout=sp.PIPE, stderr=sp.PIPE)


### PR DESCRIPTION
## Brief description
Add I/O and obsop for geostationary SST (resolved #133)

## Features added
1.  Add module `support/io/m_ncio.f90` for convenient IO of NetCDF files.
2. Add module `src/obs/read_geostationary.f90` for read in SST retrievals from geostationary satellites.
3. Add obsop `src/obs/obsop_sst_geostationary.f90` for geostationary SST simulation.
4. Update `utils/obs_proc/level-2/get_l2p_ghrsst_geostationary.py` for getting geostationary SST.
5. Update CMAKE.

Supported geostationary satellites include:
1. GOES 16/17 ABI
2. Himawari-8 AHI
3. MSG 01/02/03/04 SEVIRI
4. GOES 13/14/15 Imager

## Bugs fixed

## Test changes
1. Update `get_data` and `build_gfortran` to ensure they work with updated Ubuntu.

## Documentation changes
N/A

## Does this create a breaking change?
N/A