### PR TITLE
Add CI tests for obsop of MOM6-LEKTF (resolve #137)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build_gfortran
+name: build
 
 on:
   push:

--- a/.github/workflows/test_obsop.yml
+++ b/.github/workflows/test_obsop.yml
@@ -1,0 +1,41 @@
+name: test_obsop
+
+on:
+  push:
+  pull_request:
+
+env:
+  BUILD_TYPE: Debug
+
+jobs:
+  test_obsop:
+    strategy:
+      matrix: 
+        model: [mom6]
+      fail-fast: false
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: "install mpi, netcdf, hdf5"
+      run: |
+           sudo apt-get update
+           sudo apt install mpich   
+           sudo apt install libnetcdf-dev libnetcdff-dev netcdf-bin
+           sudo apt install hdf5-tools libhdf5-dev
+ 
+    - name: "build"
+      run: |
+           cmake -B ${{github.workspace}}/build_ocnletkf -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_Fortran_COMPILER=gfortran -DSOLO_BUILD=ON -DMODEL=${{matrix.model}}
+           cmake --build ${{github.workspace}}/build_ocnletkf --config ${{env.BUILD_TYPE}}
+
+    - name: "test obsop if model == mom6"
+      if: matrix.model == 'mom6'
+      run: |
+           git clone https://github.com/gmao-cda/MOM6-LETKF-Data.git
+           cd MOM6-LETKF-Data && mkdir build && cd build && pwd
+           cmake .. -DMODEL=mom6 -DEXECUTABLE_DIR=${{github.workspace}}/build_ocnletkf/src -DTEST_OBSOP=ON
+           ctest --rerun-failed --output-on-failure
+
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Ocean-LETKF:  
-[![build gfortran](https://github.com/UMD-AOSC/Ocean-LETKF/actions/workflows/build_gfortran.yml/badge.svg)](https://github.com/UMD-AOSC/Ocean-LETKF/actions/workflows/build_gfortran.yml)
+[![build gfortran](https://github.com/UMD-AOSC/Ocean-LETKF/actions/workflows/build.yml/badge.svg)](https://github.com/UMD-AOSC/Ocean-LETKF/actions/workflows/build.yml)
 
 Main repository for the Ocean-LETKF development
 


### PR DESCRIPTION
## Brief description
Add tests for obsop_sst_geostationary and obsop_sss with the MOM6-LETKF test data from https://github.com/gmao-cda/MOM6-LETKF-Data.git  (resolve #137)

## Features added
1.  Create MOM6-LETKF test data repo at https://github.com/gmao-cda/MOM6-LETKF-Data.git. (No github lfs)
2. Add `test_obsop_sst_geo_msg01.sh` for L2 MSG01 SST.
3. Add `test_obsop_sst_geo_g16_abi.sh` for L2 GOES-16 ABI SST.
4. Add `test_obsop_sss_l2.sh` for L2 SMAP SSS.
5. Add `test_obsop_sss_l3.sh` for L3 SMAP SSS.


## Bugs fixed

## Test changes
1. Add workflow `test_obsop` for testing obsop:
   1. Add 2 tests for obsop_sst_geostationary (L2 MSG01, and GOES-16 ABI SST).
   2. Add 2 tests for obsop_sst (L2 & L3 SMAP SSS).

## Documentation changes
N/A

## Does this create a breaking change?
N/A