### PR TITLE
Fix the bug caused by uninitialized arrays obsqc0 (Fix #155)

### DIFF
--- a/src/letkf/letkf_obs.f90.new
+++ b/src/letkf/letkf_obs.f90.new
@@ -133,6 +133,7 @@ SUBROUTINE set_letkf_obs
   ALLOCATE( obstime(nobs_in) ) !(DRIFTERS)
   obshdxf = 0.0d0
   obserr = 0.0d0
+  obsqc0 = 0
 
   !-----------------------------------------------------------------------------
   ! LOOP of timeslots


### PR DESCRIPTION
## Brief description
1. Fix the bug due to uninitialized arrays `obsqc0` by explicitly assigning it to zero (Fix #155 )


## Features added
N/A

## Bugs fixed
See brief description

## Test changes
N/A

## Documentation changes
N/A

## Does this create a breaking change?
N/A

@sanAkel can you review it? Thank you!