### PR TITLE
remove dependence on ocean_hgrid (resolve #162)

### DIFF
--- a/src/model_specific/mom6/common_mom6.f90
+++ b/src/model_specific/mom6/common_mom6.f90
@@ -189,9 +189,8 @@ SUBROUTINE set_common_oceanmodel
   ! Close the grid files:
   !-----------------------------------------------------------------------------
   call check( NF90_CLOSE(ncid) )
-!!call check( NF90_CLOSE(ncid1) )
   call check( NF90_CLOSE(ncid2) )
-! call check( NF90_CLOSE(ncid3) )
+  call check( NF90_CLOSE(ncid3) )
 
   ! Set model variables that depend on initialization and further processing.
   ! (e.g. lon0, lat0, lonf, latf, wrapgap, ...)
@@ -701,7 +700,6 @@ SUBROUTINE read_restart(infile,v3d,v2d,prec)
   USE params_letkf, ONLY: DO_UPDATE_H
   USE vars_model,   ONLY: SSHclm_m
   USE params_model, ONLY: rsrt_tsbase, rsrt_uvbase, rsrt_hbase
-  USE params_model, ONLY: rsrt_lon_name, rsrt_lat_name, rsrt_lev_name
   USE params_model, ONLY: rsrt_temp_name, rsrt_salt_name
   USE params_model, ONLY: rsrt_u_name, rsrt_v_name
   USE params_model, ONLY: rsrt_h_name, rsrt_ssh_name
@@ -983,7 +981,6 @@ SUBROUTINE write_restart(outfile,v3d_in,v2d_in,prec)
   USE params_letkf, ONLY: DO_UPDATE_H, DO_SLA
   USE vars_model,   ONLY: SSHclm_m
   USE params_model, ONLY: rsrt_tsbase, rsrt_uvbase, rsrt_hbase
-  USE params_model, ONLY: rsrt_lon_name, rsrt_lat_name, rsrt_lev_name
   USE params_model, ONLY: rsrt_temp_name, rsrt_salt_name
   USE params_model, ONLY: rsrt_u_name, rsrt_v_name
   USE params_model, ONLY: rsrt_h_name, rsrt_ssh_name

--- a/src/model_specific/mom6/common_mom6.f90
+++ b/src/model_specific/mom6/common_mom6.f90
@@ -45,7 +45,6 @@ SUBROUTINE set_common_oceanmodel
   INTEGER :: ncid,ncid2,ncid3,varid,dimid
   CHARACTER(NF90_MAX_NAME) :: dimname
   LOGICAL :: ex
-  REAL(r_size) :: dlat, dlon, d2, d3
   REAL(r_dble), ALLOCATABLE, DIMENSION(:,:) :: r8work2d
   REAL(r_size),PARAMETER :: min_layer_thickness = 1.0d-3 
 

--- a/src/model_specific/mom6/common_mom6.f90
+++ b/src/model_specific/mom6/common_mom6.f90
@@ -136,6 +136,8 @@ SUBROUTINE set_common_oceanmodel
   WRITE(6,*) "lat2d(1,1) = ", lat2d(1,1)
   WRITE(6,*) "lat2d(nlon,nlat) = ", lat2d(nlon,nlat)
 
+  DEALLOCATE(r8work2d)
+
   !-----------------------------------------------------------------------------
   ! kmt data
   !-----------------------------------------------------------------------------
@@ -261,7 +263,6 @@ SUBROUTINE read_diag(infile,v3d,v2d,prec_in)
   USE params_model, ONLY: nv3d, nv2d
   USE params_model, ONLY: iv3d_u, iv3d_v, iv3d_t, iv3d_s
   USE params_model, ONLY: iv2d_sst, iv2d_sss, iv2d_ssh
-  USE params_model, ONLY: diag_lon_name, diag_lat_name, diag_lev_name
   USE params_model, ONLY: diag_temp_name, diag_salt_name
   USE params_model, ONLY: diag_u_name, diag_v_name, diag_h_name
   USE params_model, ONLY: diag_ssh_name, diag_sst_name, diag_sss_name

--- a/src/model_specific/mom6/common_mom6.f90
+++ b/src/model_specific/mom6/common_mom6.f90
@@ -38,11 +38,11 @@ SUBROUTINE set_common_oceanmodel
   USE params_model, ONLY: grid_lon2d_name, grid_lat2d_name
   USE params_model, ONLY: grid_wet_name, grid_depth_name, grid_height_name
   USE params_model, ONLY: grid_h_name
-  USE params_model, ONLY: gridfile, gridfile2, gridfile3
+  USE params_model, ONLY: gridfile1, gridfile2, gridfile3
   USE params_model, ONLY: grid_nlon_name, grid_nlat_name, grid_nlev_name
 
   INTEGER :: i,j,k
-  INTEGER :: ncid,ncid2,ncid3,varid,dimid
+  INTEGER :: ncid1,ncid2,ncid3,varid,dimid
   CHARACTER(NF90_MAX_NAME) :: dimname
   LOGICAL :: ex
   REAL(r_dble), ALLOCATABLE, DIMENSION(:,:) :: r8work2d
@@ -54,32 +54,32 @@ SUBROUTINE set_common_oceanmodel
   !-----------------------------------------------------------------------------
   ! Open grid_spec.nc grid specification file for MOM6
   !-----------------------------------------------------------------------------
-  INQUIRE(FILE=trim(gridfile),EXIST=ex)
+  INQUIRE(FILE=trim(gridfile1),EXIST=ex)
   IF(.not. ex) THEN
-    WRITE(6,*) "The file does not exist: ", trim(gridfile)
+    WRITE(6,*) "The file does not exist: ", trim(gridfile1)
     WRITE(6,*) "Exiting common_mom6.f90..."
     STOP (2)
   ENDIF
-  WRITE(6,'(A)') '  >> accessing file: ', trim(gridfile)
-  call check( NF90_OPEN(trim(gridfile),NF90_NOWRITE,ncid) )
+  WRITE(6,'(A)') '  >> accessing file: ', trim(gridfile1)
+  call check( NF90_OPEN(trim(gridfile1),NF90_NOWRITE,ncid1) )
 
   !-----------------------------------------------------------------------------
   ! Read grid dimensions
   !-----------------------------------------------------------------------------
 #ifdef DYNAMIC
   WRITE(6,*) "Reading x dimension (lon)..."
-  call check( NF90_INQ_DIMID(ncid,trim(grid_nlon_name),dimid) )   ! Longitude for T-cell
-  call check( NF90_INQUIRE_DIMENSION(ncid,dimid,len=nlon) )
+  call check( NF90_INQ_DIMID(ncid1,trim(grid_nlon_name),dimid) )   ! Longitude for T-cell
+  call check( NF90_INQUIRE_DIMENSION(ncid1,dimid,len=nlon) )
   WRITE(6,*) "nlon = ", nlon
 
   WRITE(6,*) "Reading y dimension (lat)..."
-  call check( NF90_INQ_DIMID(ncid,trim(grid_nlat_name),dimid) )   ! Latitude for T-cell
-  call check( NF90_INQUIRE_DIMENSION(ncid,dimid,len=nlat) )
+  call check( NF90_INQ_DIMID(ncid1,trim(grid_nlat_name),dimid) )   ! Latitude for T-cell
+  call check( NF90_INQUIRE_DIMENSION(ncid1,dimid,len=nlat) )
   WRITE(6,*) "nlat = ", nlat
 
   WRITE(6,*) "Reading z dimension (lev)..."
-  call check( NF90_INQ_DIMID(ncid,trim(grid_nlev_name),dimid) )   ! Level for T-cell
-  call check( NF90_INQUIRE_DIMENSION(ncid,dimid,len=nlev) )
+  call check( NF90_INQ_DIMID(ncid1,trim(grid_nlev_name),dimid) )   ! Level for T-cell
+  call check( NF90_INQUIRE_DIMENSION(ncid1,dimid,len=nlev) )
   WRITE(6,*) "nlev = ", nlev
 #endif
 
@@ -92,23 +92,23 @@ SUBROUTINE set_common_oceanmodel
   !-----------------------------------------------------------------------------
   ! Get grid variables
   !-----------------------------------------------------------------------------
-  call check( NF90_INQ_VARID(ncid,trim(grid_lon_name),varid) )   ! Longitude for T-cell
-  call check( NF90_GET_VAR(ncid,varid,lon) )
+  call check( NF90_INQ_VARID(ncid1,trim(grid_lon_name),varid) )   ! Longitude for T-cell
+  call check( NF90_GET_VAR(ncid1,varid,lon) )
   WRITE(6,*) "lon(1) = ", lon(1)
   WRITE(6,*) "lon(nlon) = ", lon(nlon)
-  call check( NF90_INQ_VARID(ncid,trim(grid_lat_name),varid) )   ! Latitude for T-cell
-  call check( NF90_GET_VAR(ncid,varid,lat) )
+  call check( NF90_INQ_VARID(ncid1,trim(grid_lat_name),varid) )   ! Latitude for T-cell
+  call check( NF90_GET_VAR(ncid1,varid,lat) )
   WRITE(6,*) "lat(1) = ", lat(1)
   WRITE(6,*) "lat(nlat) = ", lat(nlat)
-  call check( NF90_INQ_VARID(ncid,trim(grid_lev_name),varid) )      ! depth of T-cell
-  call check( NF90_GET_VAR(ncid,varid,lev) )
+  call check( NF90_INQ_VARID(ncid1,trim(grid_lev_name),varid) )      ! depth of T-cell
+  call check( NF90_GET_VAR(ncid1,varid,lev) )
   WRITE(6,*) "lev(1) = ", lev(1)
   WRITE(6,*) "lev(nlev) = ", lev(nlev)
 
   !-----------------------------------------------------------------------------
   ! lon2d, lat2
   !-----------------------------------------------------------------------------
-!!STEVE:MOM6: open new gridfile (ocean_hgrid.nc, gridfile3)
+!!STEVE:MOM6: open new gridfile (ocean_static.nc, gridfile3)
   INQUIRE(FILE=trim(gridfile3),EXIST=ex)
   if (.not. ex) then
     WRITE(6,*) "The file does not exist: ", trim(gridfile3)
@@ -141,8 +141,8 @@ SUBROUTINE set_common_oceanmodel
   ! kmt data
   !-----------------------------------------------------------------------------
   !STEVE:MOM6: sum(h>0) (from MOM.res.nc) to find ocean layer <reference> depth, where depth > 0 (from ocean_togog.nc)
-  call check( NF90_INQ_VARID(ncid,trim(grid_h_name),varid) ) ! number of vertical T-cells
-  call check( NF90_GET_VAR(ncid,varid,height) )
+  call check( NF90_INQ_VARID(ncid1,trim(grid_h_name),varid) ) ! number of vertical T-cells
+  call check( NF90_GET_VAR(ncid1,varid,height) )
   WRITE(6,*) "h(1,1,1) = ", height(1,1,1)
   WRITE(6,*) "h(nlon,nlat,nlev) = ", height(nlon,nlat,nlev)
 
@@ -187,7 +187,7 @@ SUBROUTINE set_common_oceanmodel
   !-----------------------------------------------------------------------------
   ! Close the grid files:
   !-----------------------------------------------------------------------------
-  call check( NF90_CLOSE(ncid) )
+  call check( NF90_CLOSE(ncid1) )
   call check( NF90_CLOSE(ncid2) )
   call check( NF90_CLOSE(ncid3) )
 

--- a/src/model_specific/mom6/common_mom6.f90
+++ b/src/model_specific/mom6/common_mom6.f90
@@ -47,7 +47,7 @@ SUBROUTINE set_common_oceanmodel
   CHARACTER(NF90_MAX_NAME) :: dimname
   LOGICAL :: ex
   REAL(r_size) :: dlat, dlon, d2, d3
-  REAL(r_size), ALLOCATABLE, DIMENSION(:,:) :: work2d
+  REAL(r_dble), ALLOCATABLE, DIMENSION(:,:) :: r8work2d
   REAL(r_size),PARAMETER :: min_layer_thickness = 1.0d-3 
 
   WRITE(6,'(A)') 'Hello from set_common_oceanmodel'
@@ -120,25 +120,19 @@ SUBROUTINE set_common_oceanmodel
   WRITE(6,'(A)') '  >> accessing file: ', trim(gridfile3)
   call check( NF90_OPEN(trim(gridfile3),NF90_NOWRITE,ncid3) )
 
-  !STEVE: temporary until I figure out how to use ocean_hgrid 'supergrid' appropriately:
-  ALLOCATE(work2d(nlon2d,nlat2d))
-
+  ALLOCATE(r8work2d(nlon,nlat))
   WRITE(6,*) "Reading x coordinate (lon)..."
   call check( NF90_INQ_VARID(ncid3,trim(grid_lon2d_name),varid) )   ! Longitude for T-cell
-! call check( NF90_GET_VAR(ncid3,varid,lon2d) )
-  call check( NF90_GET_VAR(ncid3,varid,work2d) )    !STEVE: (ISSUE) ask GFDL for clarification
-  !lon2d = work2d(1:nlon2d:2,1:nlat2d:2)             !STEVE: (ISSUE) ask GFDL for clarification
-  lon2d = work2d(2:nlon2d:2,2:nlat2d:2)  !CDA: geolon (lon of T-Cell) calculated from supergrid x
+  call check( NF90_GET_VAR(ncid3,varid,r8work2d) )  
+  lon2d = REAL(r8work2d, r_size)
 
   WRITE(6,*) "lon2d(1,1) = ", lon2d(1,1)
   WRITE(6,*) "lon2d(nlon,nlat) = ", lon2d(nlon,nlat)
 
   WRITE(6,*) "Reading y coordinate (lat)..."
   call check( NF90_INQ_VARID(ncid3,trim(grid_lat2d_name),varid) )   ! Latitude for T-cell
-! call check( NF90_GET_VAR(ncid3,varid,lat2d) )
-  call check( NF90_GET_VAR(ncid3,varid,work2d) )    !STEVE: (ISSUE) ask GFDL for clarification
-  !lat2d = work2d(1:nlon2d:2,1:nlat2d:2)             !STEVE: (ISSUE) ask GFDL for clarification
-  lat2d = work2d(2:nlon2d:2,2:nlat2d:2)    !CDA: geolat (lat of T-Cell) calculated from supergrid y
+  call check( NF90_GET_VAR(ncid3,varid,r8work2d) )   
+  lat2d = REAL(r8work2d, r_size)
 
   WRITE(6,*) "lat2d(1,1) = ", lat2d(1,1)
   WRITE(6,*) "lat2d(nlon,nlat) = ", lat2d(nlon,nlat)

--- a/src/model_specific/mom6/common_mom6.f90
+++ b/src/model_specific/mom6/common_mom6.f90
@@ -30,7 +30,6 @@ SUBROUTINE set_common_oceanmodel
   USE params_model, ONLY: nlon, nlat, nlev
   USE params_model, ONLY: nlon2d, nlat2d
   USE vars_model,   ONLY: SSHclm_m, lon, lat, lon2d, lat2d, lev
-  USE vars_model,   ONLY: dx, dy, area_t
   USE vars_model,   ONLY: height, kmt, depth, wet, phi0, kmt0
   USE vars_model,   ONLY: set_vars_model
   USE params_model, ONLY: initialize_params_model
@@ -108,7 +107,7 @@ SUBROUTINE set_common_oceanmodel
   WRITE(6,*) "lev(nlev) = ", lev(nlev)
 
   !-----------------------------------------------------------------------------
-  ! lon2d, lat2, dx, and dy
+  ! lon2d, lat2
   !-----------------------------------------------------------------------------
 !!STEVE:MOM6: open new gridfile (ocean_hgrid.nc, gridfile3)
   INQUIRE(FILE=trim(gridfile3),EXIST=ex)
@@ -136,35 +135,6 @@ SUBROUTINE set_common_oceanmodel
 
   WRITE(6,*) "lat2d(1,1) = ", lat2d(1,1)
   WRITE(6,*) "lat2d(nlon,nlat) = ", lat2d(nlon,nlat)
-
-  !STEVE: I don't really need this anymore with the kdtree-based search
-  if (.true.) then !STEVE: this is TEMPORARY, until I figure out how to use the ocean_hgrid.nc data
-    i=0
-    j=0
-    dx=0.0
-    dy=0.0
-    area_t=0.0
-    do j=2,nlat-1
-      dlat = (lat(j+1) - lat(j-1))/2.0
-      d2 = (sin(dlat/2.0))**2 
-      d3 = 2 * atan2( sqrt(d2), sqrt(1-d2) )
-      dy(:,j) = re * d3
- 
-      do i=2,nlon-1
-        dlon = (lon(i+1) - lon(i-1))/2.0
-        d2 = cos(lat(j-1)) * cos(lat(j+1)) * (sin(dlon/2.0))**2
-        d3 = 2 * atan2( sqrt(d2), sqrt(1-d2) ) 
-        dx(i,j) = re * d3
-        area_t(i,j) = dx(i,j)*dy(i,j)
-      enddo
-    enddo
-  endif
-
-! WRITE(6,*) "Using dx and dy from netcdf file: ", gridfile3
-  WRITE(6,*) "dx(1,1) = ", dx(1,1)
-  WRITE(6,*) "dx(nlon,nlat) = ", dx(nlon,nlat)
-  WRITE(6,*) "dy(1,1) = ", dy(1,1)
-  WRITE(6,*) "dy(nlon,nlat) = ", dy(nlon,nlat)
 
   !-----------------------------------------------------------------------------
   ! kmt data

--- a/src/model_specific/mom6/common_mpi_mom6.f90
+++ b/src/model_specific/mom6/common_mpi_mom6.f90
@@ -23,7 +23,6 @@ MODULE common_mpi_oceanmodel
   INTEGER,ALLOCATABLE,SAVE :: nij1node(:)
   REAL(r_size),ALLOCATABLE,SAVE :: phi1(:)
   REAL(r_size),ALLOCATABLE,SAVE :: kmt1(:)         !(OCEAN)
-  REAL(r_size),ALLOCATABLE,SAVE :: dx1(:),dy1(:)
   REAL(r_size),ALLOCATABLE,SAVE :: lon1(:),lat1(:)
   REAL(r_size),ALLOCATABLE,SAVE :: i1(:),j1(:)     !(OCEAN) splits grid coordinates out into list like ijs
 
@@ -38,7 +37,6 @@ CONTAINS
 SUBROUTINE set_common_mpi_oceanmodel
 
   USE params_model, ONLY: nlon, nlat
-  USE vars_model,   ONLY: dx, dy
   USE vars_model,   ONLY: lon, lat, kmt0, phi0
   USE vars_model,   ONLY: lon2d, lat2d !, lev2d !STEVE: I'm assuming I'll need this one day
 
@@ -84,8 +82,6 @@ SUBROUTINE set_common_mpi_oceanmodel
   if (dodebug) WRITE(6,*) "ALLOCATING fields to convert to vectorized form..."
   ALLOCATE(phi1(nij1))
   ALLOCATE(kmt1(nij1))               !(OCEAN)
-  ALLOCATE(dx1(nij1))
-  ALLOCATE(dy1(nij1))
   ALLOCATE(lon1(nij1))
   ALLOCATE(lat1(nij1))
   ALLOCATE(i1(nij1))                 !(OCEAN)
@@ -96,12 +92,10 @@ SUBROUTINE set_common_mpi_oceanmodel
   ALLOCATE(v2dg(nlon,nlat,nv0))
 
   ! Distribute that data to the appropriate processors
-  if (dodebug) WRITE(6,*) "Converting dx, dy, lon, lat, i, j, phi0, and kmt0 to vectorized form..."
+  if (dodebug) WRITE(6,*) "Converting lon, lat, i, j, phi0, and kmt0 to vectorized form..."
   v2dg=0.0
   do j=1,nlat
     ! 2D and 1D Data stored in first layer:
-    v2dg(:,j,1) = SNGL(dx(:,j))
-    v2dg(:,j,2) = SNGL(dy(:,j))
     ! 2D Data stored in second layer:
     v2dg(:,j,3) = SNGL(lon2d(:,j))
     v2dg(:,j,4) = SNGL(lat2d(:,j))
@@ -117,8 +111,6 @@ SUBROUTINE set_common_mpi_oceanmodel
   if (dodebug) WRITE(6,*) "Calling scatter_grd_mpi_small..."
   CALL scatter_grd_mpi_small(0,v2dg,v2d,nlon,nlat,nv0)
 
-  dx1(:)  = v2d(:,1)
-  dy1(:)  = v2d(:,2)
   lon1(:) = v2d(:,3)
   lat1(:) = v2d(:,4)
   kmt1(:) = v2d(:,5)                 !(OCEAN)

--- a/src/model_specific/mom6/common_mpi_mom6.f90
+++ b/src/model_specific/mom6/common_mpi_mom6.f90
@@ -87,7 +87,7 @@ SUBROUTINE set_common_mpi_oceanmodel
   ALLOCATE(i1(nij1))                 !(OCEAN)
   ALLOCATE(j1(nij1))                 !(OCEAN)
 
-  nv0=8
+  nv0=6
   ALLOCATE(v2d(nij1,nv0))
   ALLOCATE(v2dg(nlon,nlat,nv0))
 
@@ -97,27 +97,25 @@ SUBROUTINE set_common_mpi_oceanmodel
   do j=1,nlat
     ! 2D and 1D Data stored in first layer:
     ! 2D Data stored in second layer:
-    v2dg(:,j,3) = SNGL(lon2d(:,j))
-    v2dg(:,j,4) = SNGL(lat2d(:,j))
-    v2dg(:,j,5) = SNGL(kmt0(:,j))
-    v2dg(:,j,6) = SNGL(phi0(:,j))  !STEVE: WARNING - this needs to be generalized to the specified dimensions
+    v2dg(:,j,1) = SNGL(lon2d(:,j))
+    v2dg(:,j,2) = SNGL(lat2d(:,j))
+    v2dg(:,j,3) = SNGL(kmt0(:,j))
+    v2dg(:,j,4) = SNGL(phi0(:,j))  !STEVE: WARNING - this needs to be generalized to the specified dimensions
     !STEVE: For custom localization: (need to know how the grid points are distributed per node)
     do i=1,nlon                             !(OCEAN)
-      v2dg(i,j,7) = REAL(i,r_sngl)          !(OCEAN)
+      v2dg(i,j,5) = REAL(i,r_sngl)          !(OCEAN)
     enddo                                   !(OCEAN)
-    v2dg(:,j,8) = REAL(j,r_sngl)            !(OCEAN)
-    !v2dg(:,j,9) = SNGL(lev2d(:,j))
+    v2dg(:,j,6) = REAL(j,r_sngl)            !(OCEAN)
   enddo
   if (dodebug) WRITE(6,*) "Calling scatter_grd_mpi_small..."
   CALL scatter_grd_mpi_small(0,v2dg,v2d,nlon,nlat,nv0)
 
-  lon1(:) = v2d(:,3)
-  lat1(:) = v2d(:,4)
-  kmt1(:) = v2d(:,5)                 !(OCEAN)
-  phi1(:) = v2d(:,6)                 !(OCEAN)
-  i1(:)   = v2d(:,7)                 !(OCEAN)
-  j1(:)   = v2d(:,8)                 !(OCEAN)
-  !lev1(:) = v2d(:,9)
+  lon1(:) = v2d(:,1)
+  lat1(:) = v2d(:,2)
+  kmt1(:) = v2d(:,3)                 !(OCEAN)
+  phi1(:) = v2d(:,4)                 !(OCEAN)
+  i1(:)   = v2d(:,5)                 !(OCEAN)
+  j1(:)   = v2d(:,6)                 !(OCEAN)
 
   DEALLOCATE(v2d,v2dg)
   if (dodebug) WRITE(6,*) "Finished set_common_mpi_oceanmodel..."

--- a/src/model_specific/mom6/input_nml_mom6.f90
+++ b/src/model_specific/mom6/input_nml_mom6.f90
@@ -39,9 +39,6 @@ PRIVATE
                               grid_wet_name,& !
                               grid_depth_name,& !
                               grid_height_name,& !
-                              diag_lon_name,& !
-                              diag_lat_name,& !
-                              diag_lev_name,& !
                               diag_temp_name,& !
                               diag_salt_name,& !
                               diag_u_name,& !

--- a/src/model_specific/mom6/input_nml_mom6.f90
+++ b/src/model_specific/mom6/input_nml_mom6.f90
@@ -55,9 +55,6 @@ PRIVATE
                               diag_DO_ssh, & !
                               diag_DO_sst, & !
                               diag_DO_sss, & !
-                              rsrt_lon_name,& !
-                              rsrt_lat_name,& !
-                              rsrt_lev_name,& !
                               rsrt_temp_name,& !
                               rsrt_salt_name,& !
                               rsrt_u_name,& !

--- a/src/model_specific/mom6/input_nml_mom6.f90
+++ b/src/model_specific/mom6/input_nml_mom6.f90
@@ -12,13 +12,12 @@ PRIVATE
 #ifdef DYNAMIC
   ! Grid dimensions are set in params_model.f90, but only used in a namelist if compiled for dynamic arrays:
   NAMELIST /grid_dimensions_nml/ & 
-                              nlon, &      ! number of longitude grid points (Can be specified via namelist or in netcdf gridfile)
+                              nlon, &      ! number of longitude grid points (Can be specified via namelist or in netcdf gridfile1)
                               nlat, &      ! number of latitude grid points
                               nlev         ! number of model levels
 #endif
 
-  NAMELIST /params_model_nml/ gridfile, &  ! MOM4 grid_spec.nc file 
-                              gridfile1,&  !
+  NAMELIST /params_model_nml/ gridfile1,&  !
                               gridfile2,&  !
                               gridfile3,&  !
                               grid_nlon_name, & !

--- a/src/model_specific/mom6/params_model.f90
+++ b/src/model_specific/mom6/params_model.f90
@@ -128,9 +128,6 @@ PUBLIC
   CHARACTER(slen) :: rsrt_uvbase = 'MOM.res_1.nc' !(v and ave_ssh/sfc)
   CHARACTER(slen) :: rsrt_hbase
   ! variable names in restart file:
-  CHARACTER(slen_short) :: rsrt_lon_name = 'lonh'
-  CHARACTER(slen_short) :: rsrt_lat_name = 'lath'
-  CHARACTER(slen_short) :: rsrt_lev_name = 'Layer'
   CHARACTER(slen_short) :: rsrt_temp_name = 'Temp'
   CHARACTER(slen_short) :: rsrt_salt_name = 'Salt'
   CHARACTER(slen_short) :: rsrt_u_name = 'u'

--- a/src/model_specific/mom6/params_model.f90
+++ b/src/model_specific/mom6/params_model.f90
@@ -103,9 +103,6 @@ PUBLIC
   CHARACTER(slen) :: diag_uvbase = 'MOM.diag.nc'  !(v and ave_ssh/sfc)
   CHARACTER(slen) :: diag_hbase
   ! variable names in diag file:
-  CHARACTER(slen_short) :: diag_lon_name = 'xh'
-  CHARACTER(slen_short) :: diag_lat_name = 'yh'
-  CHARACTER(slen_short) :: diag_lev_name = 'zl'
   CHARACTER(slen_short) :: diag_temp_name = 'temp'
   CHARACTER(slen_short) :: diag_salt_name = 'salt'
   CHARACTER(slen_short) :: diag_u_name = 'u'

--- a/src/model_specific/mom6/params_model.f90
+++ b/src/model_specific/mom6/params_model.f90
@@ -73,8 +73,7 @@ PUBLIC
 
   CHARACTER(14) :: SSHclm_file = 'aEtaCds9399.nc'
 
-  CHARACTER(slen) :: gridfile  = 'MOM.res.nc'
-  CHARACTER(slen) :: gridfile1 = 'MOM.res_1.nc'
+  CHARACTER(slen) :: gridfile1 = 'MOM.res.nc'
   CHARACTER(slen) :: gridfile2 = 'ocean_topog.nc'
   CHARACTER(slen) :: gridfile3 = 'ocean_hgrid.nc'
 

--- a/src/model_specific/mom6/vars_model.f90
+++ b/src/model_specific/mom6/vars_model.f90
@@ -19,8 +19,6 @@ PUBLIC
   REAL(r_size),ALLOCATABLE,DIMENSION(:,:),SAVE :: lat2d !(nlon,nlat)              !(2DGRID)(For irregular grids)
   REAL(r_size),ALLOCATABLE,DIMENSION(:,:),SAVE :: lev2d !(nlon,nlat)              !(2DGRID)(For irregular grids)
 
-  REAL(r_size),ALLOCATABLE,DIMENSION(:,:),SAVE :: dx !(nlon,nlat)
-  REAL(r_size),ALLOCATABLE,DIMENSION(:,:),SAVE :: dy !(nlon,nlat)
   REAL(r_size),ALLOCATABLE,DIMENSION(:,:),SAVE :: phi0 !(nlon,nlat)
   REAL(r_size),ALLOCATABLE,DIMENSION(:,:),SAVE :: kmt0 !(nlon,nlat)               !(OCEAN)
   REAL(r_size),ALLOCATABLE,DIMENSION(:,:,:),SAVE :: height !(nlon,nlat,nlev)             !(OCEAN)
@@ -43,8 +41,6 @@ PUBLIC
   REAL(r_size),DIMENSION(nlon,nlat),SAVE :: lat2d !(nlon,nlat)              !(2DGRID)(TRIPOLAR)
   REAL(r_size),DIMENSION(nlon,nlat),SAVE :: lev2d !(nlon,nlat)              !(2DGRID)(TRIPOLAR)
 
-  REAL(r_size),DIMENSION(nlon,nlat),SAVE :: dx !(nlon,nlat)
-  REAL(r_size),DIMENSION(nlon,nlat),SAVE :: dy !(nlon,nlat)
   REAL(r_size),DIMENSION(nlon,nlat),SAVE :: phi0 !(nlon,nlat)
   REAL(r_size),DIMENSION(nlon,nlat),SAVE :: kmt0 !(nlon,nlat)               !(OCEAN)
   REAL(r_size),DIMENSION(nlon,nlat,nlev),SAVE :: height !(nlon,nlat,nlev)             !(OCEAN)
@@ -100,8 +96,6 @@ SUBROUTINE initialize_vars_model
   ALLOCATE(lev(nlev))
   ALLOCATE(lon2d(nlon,nlat))
   ALLOCATE(lat2d(nlon,nlat))
-  ALLOCATE(dx(nlon,nlat))
-  ALLOCATE(dy(nlon,nlat))
   ALLOCATE(phi0(nlon,nlat))
   ALLOCATE(kmt0(nlon,nlat))
   ALLOCATE(SSHclm_m(nlon,nlat))

--- a/src/model_specific/mom6/vars_model.f90
+++ b/src/model_specific/mom6/vars_model.f90
@@ -21,7 +21,6 @@ PUBLIC
 
   REAL(r_size),ALLOCATABLE,DIMENSION(:,:),SAVE :: dx !(nlon,nlat)
   REAL(r_size),ALLOCATABLE,DIMENSION(:,:),SAVE :: dy !(nlon,nlat)
-  REAL(r_size),ALLOCATABLE,DIMENSION(:,:),SAVE :: area_t !(nlon,nlat)
   REAL(r_size),ALLOCATABLE,DIMENSION(:,:),SAVE :: phi0 !(nlon,nlat)
   REAL(r_size),ALLOCATABLE,DIMENSION(:,:),SAVE :: kmt0 !(nlon,nlat)               !(OCEAN)
   REAL(r_size),ALLOCATABLE,DIMENSION(:,:,:),SAVE :: height !(nlon,nlat,nlev)             !(OCEAN)
@@ -46,7 +45,6 @@ PUBLIC
 
   REAL(r_size),DIMENSION(nlon,nlat),SAVE :: dx !(nlon,nlat)
   REAL(r_size),DIMENSION(nlon,nlat),SAVE :: dy !(nlon,nlat)
-  REAL(r_size),DIMENSION(nlon,nlat),SAVE :: area_t !(nlon,nlat)
   REAL(r_size),DIMENSION(nlon,nlat),SAVE :: phi0 !(nlon,nlat)
   REAL(r_size),DIMENSION(nlon,nlat),SAVE :: kmt0 !(nlon,nlat)               !(OCEAN)
   REAL(r_size),DIMENSION(nlon,nlat,nlev),SAVE :: height !(nlon,nlat,nlev)             !(OCEAN)
@@ -115,7 +113,6 @@ SUBROUTINE initialize_vars_model
   ALLOCATE(dz(nlev))
 
   ALLOCATE(fcori2d(nlon,nlat))
-  ALLOCATE(area_t(nlon,nlat))
   ALLOCATE(height(nlon,nlat,nlev))
   ALLOCATE(wet(nlon,nlat))
   ALLOCATE(depth(nlon,nlat))


### PR DESCRIPTION

## Brief description
1. Use `geolon/lat` from `ocean_static.nc` as the grid input (resolve #162).
2. Remove many unused variables for MOM6
3. no-diff tests passed on several configurations on discover: cas/40nprocs, cas/45nprocs, sky/36procs, sky/72procs

## Features added
1. Use `geolon/lat` from `ocean_static.nc` as the grid input (resolve #162).
2. Remove many unused variables for MOM6

## Bugs fixed
1. Close the ncfile `gridfile3` in the `common_mom6.f90` after reading the info of `lat/lat2d`.
2. Remove the `area_t` calculation since it's no longer needed for the mom6, and it has `floating point exception` that triggers strange behaviors of compilers (e.g., output will get changed due to irrelevant additional `write(6,*)` statement).

## Test changes
N/A

## Documentation changes
N/A

## Does this create a breaking change?
N/A

