### PR TITLE
Add RTPS & RTPP (resolve #140)

### DIFF
--- a/src/letkf/params_letkf.f90
+++ b/src/letkf/params_letkf.f90
@@ -56,6 +56,10 @@ INTEGER :: localization_method=1 !1 !(OCEAN) =0 for uniform radius (default), =1
 ! < 0: 3D inflation values input from a GPV file "infl_mul.grd"
 REAL(r_size) :: cov_infl_mul = 1.0d0 !(NO INFLATION) !-1.0d0 => adaptive multiplicative inflation
 REAL(r_size) :: sp_infl_add = 0.d0 !additive inflation
+LOGICAL      :: DO_RTPP     = .false. ! set either DO_RTPP or DO_RTPS to .true., but not both
+REAL(r_size) :: rtpp_coeff  = 0.d0  ! 0.0 for no analysis relaxation, and 1.0 for relaxed to background completely
+LOGICAL      :: DO_RTPS     = .false. ! set either DO_RTPP or DO_RTPS to .true., but not both
+REAL(r_size) :: rtps_coeff  = 0.d0  ! 0.0 for no analysis relaxation, and 1.0 for relaxed to background completely
 
 !-------------------------------------------------------------------------------
 ! From common_model.f90

--- a/src/model_specific/mom6/common_mom6.f90
+++ b/src/model_specific/mom6/common_mom6.f90
@@ -1287,7 +1287,6 @@ SUBROUTINE ensmean_grd(member,nij,v3d,v2d,v3dm,v2dm)
   INTEGER :: i,k,m,n
 
 ! ALLOCATE(v3dm(nij,nlev,nv3d),v2dm(nij,nv2d))
-
   do n=1,nv3d
     do k=1,nlev
       do i=1,nij

--- a/src/model_specific/mom6/input_nml_mom6.f90
+++ b/src/model_specific/mom6/input_nml_mom6.f90
@@ -87,7 +87,11 @@ PRIVATE
                               DO_UPDATE_H, &         ! option to update model layer thicknesses based on assimilation of observations
                               localization_method, & ! localization method to be used in letkf_local.f90
                               cov_infl_mul, &        ! multiplicative inflation factor (default=1.0, i.e. none)
-                              sp_infl_add            ! additive inflation factor (default none)
+                              sp_infl_add, &         ! additive inflation factor (default none)
+                              DO_RTPP,     &         ! logical flag to do relaxation-to-prior-perturbation (default=.false.)
+                              rtpp_coeff,  &         ! default=0.0
+                              DO_RTPS,     &         ! logical flag to do relaxation-to-prior-spread (default=.false.)
+                              rtps_coeff             ! default=0.0
 
 
 


### PR DESCRIPTION
## Brief description
This PR adds two relaxation methods that are commonly used in the atmospheric EnDA. They are used to alleviate the over-shrinked analysis uncertainty due to the small ensemble size:
1.  the Relaxation to Prior Perturbation (RTPP): which relaxes the analysis perturbations towards the background perturbations, and 
2.  the Relaxation to Prior Spread (RTPS): which relaxes the analysis spread towards the background spread

Either of these two methods can be used after we get the analysis ensemble.

## Features added
1. Add RTPP and RTPS in the `letkf_tools.f90` (Resolve #140).

## Bugs fixed
N/A

## Test changes
N/A

## Documentation changes
N/A

## Does this create a breaking change?
N/A

