### PR TITLE
Add option to output OMB info (resolve #154)

### DIFF
--- a/src/letkf/letkf_obs.f90.new
+++ b/src/letkf/letkf_obs.f90.new
@@ -41,6 +41,7 @@ MODULE letkf_obs
   USE common_letkf
   USE params_letkf, ONLY: sigma_obs, sigma_obsv, sigma_obs0, gross_error, nslots, nbv
   USE params_letkf, ONLY: DO_QC_MEANDEP, DO_QC_MAXDEP
+  USE params_letkf, ONLY: DO_WRITE_OMB_MEAN
   USE params_obs    ! nobs
   USE vars_obs
 
@@ -79,6 +80,7 @@ SUBROUTINE set_letkf_obs
   INTEGER :: nj(0:nlat-1)
   INTEGER :: njs(1:nlat-1)
   CHARACTER(12) :: obsfile='obsTTNNN.dat'
+  CHARACTER(12) :: ombfile='omb_mean.dat'
   INTEGER :: nobs_in
 
   !STEVE: for adaptive observation error:
@@ -91,6 +93,8 @@ SUBROUTINE set_letkf_obs
   INTEGER :: gross_cnt,gross_2x_cnt
   !STEVE: for DO_ALTIMETRY
   REAL(r_size) :: SSH_CLM_m 
+  ! for omb diag
+  REAL(r_size),allocatable :: hx(:) ! (nobs_in)
 
   WRITE(6,'(A)') 'Hello from set_letkf_obs'
 
@@ -399,6 +403,19 @@ endif quality_control
   WRITE(6,*) "gross_2x_cnt = ", gross_2x_cnt
 
   CALL monit_dep(nobs_in,obselm,obsdep,obsqc)
+
+  if (DO_WRITE_OMB_MEAN) then
+    if (myrank == 0) then !Assuming all members have the identical obs records
+      ALLOCATE( hx(nobs_in) ) ! mean[h(x_i)]
+      hx = obsdat - obsdep
+      WRITE(6,'(A,I3.3,2A)') 'MYRANK ',myrank,' is writing omb info info file:', ombfile
+      call write_obs2(trim(ombfile),nobs_in, &
+                      obselm, obslon, obslat, obslev, &
+                      obsdat, obserr, hx,  obsqc, &
+                      obstime, qcflag_in=.false.)
+      DEALLOCATE(hx)
+    endif
+  endif
 
 !STEVE: maybe use this if there are enough observations...
 !

--- a/src/letkf/letkf_obs.f90.new
+++ b/src/letkf/letkf_obs.f90.new
@@ -410,9 +410,9 @@ endif quality_control
       hx = obsdat - obsdep
       WRITE(6,'(A,I3.3,2A)') 'MYRANK ',myrank,' is writing omb info info file:', ombfile
       call write_obs2(trim(ombfile),nobs_in, &
-                      obselm, obslon, obslat, obslev, &
-                      obsdat, obserr, hx,  obsqc, &
-                      obstime, qcflag_in=.false.)
+                      obselm, obslon, obslat, &
+                      obslev, obsdat, obserr, &
+                      hx,     obsqc,  obstime)
       DEALLOCATE(hx)
     endif
   endif

--- a/src/letkf/params_letkf.f90
+++ b/src/letkf/params_letkf.f90
@@ -28,6 +28,7 @@ REAL(r_size),SAVE :: gross_error=3.0d0    ! number of standard deviations
 ! LETKF main options
 !-------------------------------------------------------------------------------
 LOGICAL :: DO_WRITE_ENS_MEAN_SPRD = .false.  ! Indicates whether to write the ensemble mean and spread (fcst and analysis)
+LOGICAL :: DO_WRITE_OMB_MEAN = .false. ! whether write out mean[yo-h(x_i)] and other obs diag info
 
 !-------------------------------------------------------------------------------
 ! From letkf_local.f90

--- a/src/model_specific/mom6/input_nml_mom6.f90
+++ b/src/model_specific/mom6/input_nml_mom6.f90
@@ -74,6 +74,7 @@ PRIVATE
                               sigma_obst, &          ! Sigma-radius for temporal localization (not activated)
                               gross_error, &         ! number of standard deviations for quality control (all outside removed)
                               DO_WRITE_ENS_MEAN_SPRD, &  ! logical flag to write the ensemble mean and spread for the forecast and analysis fields
+                              DO_WRITE_OMB_MEAN,      &  ! logical flag to write the obs info (omb,qc,...)
                               DO_DRIFTERS, &         ! logical flag to do lagrangian drifters assimilation
                               DO_ALTIMETRY, &        ! logical flag to do altimetry data assimilation
                               DO_SLA, &              ! logical flag to use SLA for altimetry


### PR DESCRIPTION

## Brief description
This PR adds one option `DO_WRITE_OMB_MEAN` to output OMB-related info (e.g., omb, qc), which are critical for monitoring the performance of the LETKF.

## Features added
1. Add an option to write out OMB info (Resolve #154 ).

## Bugs fixed
N/A

## Test changes
N/A

## Documentation changes
N/A

## Does this create a breaking change?
N/A

