### PR TITLE
Add auto-test for obsop (resolve #137)

### DIFF
--- a/.github/workflows/test_obsop.yml
+++ b/.github/workflows/test_obsop.yml
@@ -1,0 +1,39 @@
+name: test_obsop
+
+on:
+  push:
+  pull_request:
+
+env:
+  BUILD_TYPE: Debug
+
+jobs:
+  test_obsop:
+    strategy:
+      matrix: 
+        model: [mom6]
+      fail-fast: false
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: "install mpi, netcdf, hdf5"
+      run: |
+           sudo apt-get update
+           sudo apt install mpich   
+           sudo apt install libnetcdf-dev libnetcdff-dev netcdf-bin
+           sudo apt install hdf5-tools libhdf5-dev
+ 
+    - name: "build"
+      run: |
+           cmake -B ${{github.workspace}}/build_ocnletkf -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_Fortran_COMPILER=gfortran -DSOLO_BUILD=ON -DMODEL=${{matrix.model}}
+           cmake --build ${{github.workspace}}/build_ocnletkf --config ${{env.BUILD_TYPE}}
+    - name: "test obsop if model == mom6"
+      if: matrix.model == 'mom6'
+      run: |
+           git clone https://github.com/gmao-cda/MOM6-LETKF-Data.git
+           cd MOM6-LETKF-Data && mkdir build && cd build && pwd
+           cmake .. -DMODEL=mom6 -DEXECUTABLE_DIR=${{github.workspace}}/build_ocnletkf/src -DTEST_OBSOP=ON
+           ctest --rerun-failed --output-on-failure
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ocean-LETKF:  
 [![build gfortran](https://github.com/UMD-AOSC/Ocean-LETKF/actions/workflows/build_gfortran.yml/badge.svg)](https://github.com/UMD-AOSC/Ocean-LETKF/actions/workflows/build_gfortran.yml)
+[![test_obsop](https://github.com/UMD-AOSC/Ocean-LETKF/actions/workflows/test_obsop.yml/badge.svg)](https://github.com/UMD-AOSC/Ocean-LETKF/actions/workflows/test_obsop.yml)
+[![get_data](https://github.com/UMD-AOSC/Ocean-LETKF/actions/workflows/get_data.yml/badge.svg)](https://github.com/UMD-AOSC/Ocean-LETKF/actions/workflows/get_data.yml)
 
 Main repository for the Ocean-LETKF development
 


### PR DESCRIPTION
Create obsop running test by hooking the repo https://github.com/cd10kfsu/Ocean-LETKF-Data

1. Add obsop test for L2/L3 SMAP SSS
2. Add obsop test for L2 ABI SST
3. Add obsop test for L2 MSG/SEVIRI SST


## Brief description
This PR adds auto-test for the `obsop` by using the testing data from the repo https://github.com/cd10kfsu/Ocean-LETKF-Data . The test includes
1. Add obsop test for L2/L3 SMAP SSS
2. Add obsop test for L2 ABI SST
3. Add obsop test for L2 MSG/SEVIRI SST

The status of testing will be shown in README.md

## Features added
1.  Add auto-test for `obsop` (resolve #137 ).

## Bugs fixed
N/A

## Test changes
1. Add obsop test for L2/L3 SMAP SSS
2. Add obsop test for L2 ABI SST
3. Add obsop test for L2 MSG/SEVIRI SST

## Documentation changes
N/A

## Does this create a breaking change?
N/A


