### PR TITLE
Initialize H if DO_UPDATE_H = .false. (Fix #182)

### DIFF
--- a/src/model_specific/mom6/common_mom6.f90
+++ b/src/model_specific/mom6/common_mom6.f90
@@ -807,13 +807,13 @@ SUBROUTINE read_restart(infile,v3d,v2d,prec)
   endif
 ! !STEVE: end
 
-  if (DO_UPDATE_H) then
-    !---------------------------------------------------------------------------
-    !!! h
-    !---------------------------------------------------------------------------
-    varname=rsrt_h_name
-    ivid=iv3d_h
+  !---------------------------------------------------------------------------
+  !!! h
+  !---------------------------------------------------------------------------
+  varname=rsrt_h_name
+  ivid=iv3d_h
 
+  if (DO_UPDATE_H) then
     call check( NF90_INQ_VARID(ncid,trim(varname),varid) )
 
     select case(prec)
@@ -839,6 +839,13 @@ SUBROUTINE read_restart(infile,v3d,v2d,prec)
       enddo
     endif
 !   !STEVE: end
+  else
+    v3d(:,:,:,ivid) = 0.d0
+    if (dodebug) then
+      WRITE(6,*) "POST-H"
+      WRITE(6,*) "iv3d_h, ivid:", iv3d_h, ivid
+      WRITE(6,*) "read_restart :: skip reading H, set v3d(:,:,:,iv3d_h)=0.d0"
+    endif
   endif
 
   !-----------------------------------------------------------------------------

--- a/src/model_specific/mom6/common_obs_mom6.f90.kdtree
+++ b/src/model_specific/mom6/common_obs_mom6.f90.kdtree
@@ -609,7 +609,7 @@ SUBROUTINE monit_dep(nn,elm,dep,qc)
   WRITE(6,'(A)') '== OBSERVATIONAL DEPARTURE ============================================='
   WRITE(6,'(7A12)') 'U','V','T','S','SSH','eta','SST','SSS'                                       !(OCEAN)
   WRITE(6,'(7ES12.3)') bias_u,bias_v,bias_t,bias_s,bias_ssh,bias_eta,bias_sst,bias_sss               !(OCEAN)
-  WRITE(6,'(7ES12.3)') rmse_u,rmse_v,rmse_t,rmse_s,rmse_ssh,bias_eta,rmse_sst,bias_sss               !(OCEAN)
+  WRITE(6,'(7ES12.3)') rmse_u,rmse_v,rmse_t,rmse_s,rmse_ssh,rmse_eta,rmse_sst,rmse_sss               !(OCEAN)
   WRITE(6,'(A)') '== NUMBER OF OBSERVATIONS TO BE ASSIMILATED ============================'
   WRITE(6,'(7A12)') 'U','V','T','S','SSH','eta','SST','SSS'                                       !(OCEAN)
   WRITE(6,'(7I12)') iu,iv,it,is,issh,ieta,isst,isss                                              !(OCEAN)

--- a/src/model_specific/mom6/common_obs_mom6.f90.orig
+++ b/src/model_specific/mom6/common_obs_mom6.f90.orig
@@ -440,7 +440,7 @@ SUBROUTINE monit_dep(nn,elm,dep,qc)
   WRITE(6,'(A)') '== OBSERVATIONAL DEPARTURE ============================================='
   WRITE(6,'(7A12)') 'U','V','T','S','SSH','eta','SST','SSS'                                       !(OCEAN)
   WRITE(6,'(7ES12.3)') bias_u,bias_v,bias_t,bias_s,bias_ssh,bias_eta,bias_sst,bias_sss               !(OCEAN)
-  WRITE(6,'(7ES12.3)') rmse_u,rmse_v,rmse_t,rmse_s,rmse_ssh,bias_eta,rmse_sst,bias_sss               !(OCEAN)
+  WRITE(6,'(7ES12.3)') rmse_u,rmse_v,rmse_t,rmse_s,rmse_ssh,rmse_eta,rmse_sst,rmse_sss               !(OCEAN)
   WRITE(6,'(A)') '== NUMBER OF OBSERVATIONS TO BE ASSIMILATED ============================'
   WRITE(6,'(7A12)') 'U','V','T','S','SSH','eta','SST','SSS'                                       !(OCEAN)
   WRITE(6,'(7I12)') iu,iv,it,is,issh,ieta,isst,isss                                              !(OCEAN)

--- a/src/model_specific/mom6/params_model.f90
+++ b/src/model_specific/mom6/params_model.f90
@@ -37,7 +37,6 @@ PUBLIC
   INTEGER,PARAMETER :: iv3d_t=3
   INTEGER,PARAMETER :: iv3d_s=4                !(OCEAN)
   INTEGER,PARAMETER :: iv3d_h=5                !(OCEAN) (MOM6)
-! LOGICAL           :: DO_UPDATE_H=.true.      !STEVE: put this in params_letkf.f90
 
   INTEGER,PARAMETER :: iv2d_ssh=1              !(OCEAN) ! time averaged thickness of top model grid cell (m) plus patm/(grav*rho0)
   INTEGER,PARAMETER :: iv2d_sst=2              !(OCEAN) ! time averaged sst (Kelvin) passed to atmosphere/ice model


### PR DESCRIPTION
## Brief description
When `DO_UPDATE_H=.false.`, the H field in `gues3d` is not initialized and will be assigned random numbers. This will cause the `das_letkf` breakdown due to the range check (#182).  

This PR fixes this issue by initializing the H field as 0 if `DO_UPDATE_H=.false.`. Besides, it fixes a displaying bug for observation departure monitoring

## Features added
N/A

## Bugs fixed
1. Fix #182 
2. Fix a displaying error for observation departure monitoring.

## Test changes
N/A

## Documentation changes
N/A

## Does this create a breaking change?
No.

